### PR TITLE
Run `bin/rake db:migrate`

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_24_190928) do
-
+ActiveRecord::Schema[7.0].define(version: 2021_10_24_190928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,18 +32,18 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
   create_table "browser_sessions", force: :cascade do |t|
     t.string "token", null: false, comment: "The token that will be kept in localstorage and included with API requests"
     t.bigint "human_id", null: false
-    t.datetime "last_seen_at", null: false, comment: "When the human last visited during this session"
-    t.datetime "expires_at", null: false, comment: "The time at which we should stop honoring the token and force them to log in again"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "last_seen_at", precision: nil, null: false, comment: "When the human last visited during this session"
+    t.datetime "expires_at", precision: nil, null: false, comment: "The time at which we should stop honoring the token and force them to log in again"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["human_id"], name: "index_browser_sessions_on_human_id"
   end
 
   create_table "follows", force: :cascade do |t|
     t.bigint "follower_id", null: false, comment: "Who is the person doing the following"
     t.bigint "followee_id", null: false, comment: "Who is the person being followed"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["followee_id"], name: "index_follows_on_followee_id"
     t.index ["follower_id", "followee_id"], name: "index_follows_on_follower_id_and_followee_id", unique: true
     t.index ["follower_id"], name: "index_follows_on_follower_id"
@@ -53,8 +52,8 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
   create_table "humans", force: :cascade do |t|
     t.string "handle", null: false, comment: "The handle is the human's nickname, username, or whatever you want to call it"
     t.string "email", null: false, comment: "Their email. This is how they'll log in. No passwords. Just click a link in your email."
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "share_currently_watching", default: false, null: false, comment: "Whether or not to publicly display your currently watching list on the profile page"
     t.enum "default_review_visibility", default: "anybody", null: false, comment: "Lets people specify who they generally want to share their reviews with, to save them some clicking", enum_type: "visibility"
     t.index ["email"], name: "humans_email_unique", unique: true
@@ -64,9 +63,9 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
   create_table "magic_links", force: :cascade do |t|
     t.string "email", null: false, comment: "The email address that the magic link is sent to. Following the link proves they are this human."
     t.string "token", null: false, comment: "The thing that makes this link unique, which will be part of the link"
-    t.datetime "expires_at", null: false, comment: "When the magic link stops working"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "expires_at", precision: nil, null: false, comment: "When the magic link stops working"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["token"], name: "index_magic_links_on_token", unique: true
   end
 
@@ -74,8 +73,8 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
     t.bigint "human_id", null: false, comment: "Which human saved this season"
     t.bigint "season_id", null: false, comment: "Which season did this human save"
     t.boolean "watched", default: false, null: false, comment: "Did the human watch this season yet?"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["human_id", "season_id"], name: "index_my_seasons_on_human_id_and_season_id", unique: true
     t.index ["human_id"], name: "index_my_seasons_on_human_id"
     t.index ["season_id"], name: "index_my_seasons_on_season_id"
@@ -84,8 +83,8 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
   create_table "my_shows", force: :cascade do |t|
     t.bigint "human_id", null: false, comment: "Which human has saved this show"
     t.bigint "show_id", null: false, comment: "Which show this human has saved"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "note_to_self", comment: "An optional blob of Markdown-formatted text that the human can write to remind themselves why they've added the show, or however they want to use it"
     t.enum "status", default: "might_watch", null: false, enum_type: "my_show_status"
     t.index ["human_id", "show_id"], name: "index_my_shows_on_human_id_and_show_id", unique: true
@@ -100,8 +99,8 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
     t.integer "rating", comment: "The rating between 0 and 10 (optional)"
     t.integer "viewing", null: false, comment: "Is this the person's first, second, third etc viewing of the season?"
     t.enum "visibility", default: "anybody", null: false, comment: "Who can see this review", enum_type: "visibility"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["author_id", "season_id", "viewing"], name: "index_season_reviews_on_author_id_and_season_id_and_viewing", unique: true
     t.index ["author_id"], name: "index_season_reviews_on_author_id"
     t.index ["season_id"], name: "index_season_reviews_on_season_id"
@@ -114,8 +113,8 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
     t.integer "season_number", null: false
     t.integer "episode_count", null: false
     t.string "slug", null: false, comment: "A URL-friendly slug"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "tmdb_poster_path"
     t.index ["show_id", "slug"], name: "index_seasons_on_show_id_and_slug", unique: true
     t.index ["show_id"], name: "index_seasons_on_show_id"
@@ -125,21 +124,21 @@ ActiveRecord::Schema.define(version: 2021_10_24_190928) do
   create_table "shows", force: :cascade do |t|
     t.string "title", null: false, comment: "The show's official title"
     t.string "slug", null: false, comment: "The show's title, in slug form, to go in a URL"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "tmdb_tv_id", null: false
     t.string "tmdb_poster_path"
-    t.datetime "tmdb_next_refresh_at"
+    t.datetime "tmdb_next_refresh_at", precision: nil
     t.index ["slug"], name: "index_shows_on_slug", unique: true
     t.index ["tmdb_tv_id"], name: "index_shows_on_tmdb_tv_id", unique: true
   end
 
   create_table "tmdb_api_configurations", force: :cascade do |t|
     t.string "secure_base_url", null: false
-    t.datetime "fetched_at", null: false
+    t.datetime "fetched_at", precision: nil, null: false
     t.string "poster_sizes", null: false, array: true
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["poster_sizes"], name: "index_tmdb_api_configurations_on_poster_sizes", using: :gin
   end
 


### PR DESCRIPTION
Seems like the format changed a little bit when we updated to Rails 7
perhaps?