### PR TITLE
More flexible magic link

### DIFF
--- a/app/controllers/api/magic_links_controller.rb
+++ b/app/controllers/api/magic_links_controller.rb
@@ -6,7 +6,7 @@ module API
   class MagicLinksController < ApplicationController
     def create
       authorize! { true }
-      email = params.require(:magic_link).require(:email)
+      email = params.require(:magic_link).require(:email).to_s.strip.downcase.presence
 
       # This is a "loose" validation which I think is fine.
       # I won't actually create a human until someone follows the magic link, which proves that it

--- a/app/models/magic_link.rb
+++ b/app/models/magic_link.rb
@@ -2,7 +2,6 @@
 
 # A link we email you so you can log in or sign up
 class MagicLink < ApplicationRecord
-  before_save ->(magic_link) { magic_link.email = magic_link.email.to_s.strip.downcase.presence }
   before_create -> { self.token = SecureRandom.uuid }
   before_create -> { self.expires_at = 30.minutes.from_now }
 


### PR DESCRIPTION
I want to be able to log in even when I type something like
`Foo@example.com ` with a trailing space and a capitalized letter.
That happens for me especially on mobile.