### PR TITLE
Fix episode import, take two

### DIFF
--- a/app/models/tmdb/season_details.rb
+++ b/app/models/tmdb/season_details.rb
@@ -2,9 +2,9 @@
 
 module TMDB
   class SeasonDetails < Dry::Struct
-    attribute :air_date, Types::String
+    attribute :air_date, Types::String.optional
     attribute :episodes, Types::Array do
-      attribute :air_date, Types::String
+      attribute :air_date, Types::String.optional
       attribute :episode_number, Types::Integer
       attribute :id, Types::Integer
       attribute :name, Types::String


### PR DESCRIPTION
The error message isn't too too clear but I can see that the air_date of _something_ is not present. I don't actually care about either, so I'm just marking both as optional. I suppose it makes sense that both of them could be absent.