### PR TITLE
Drop my_seasons.watched column

### DIFF
--- a/app/controllers/api/your_seasons_controller.rb
+++ b/app/controllers/api/your_seasons_controller.rb
@@ -10,13 +10,11 @@ module API
       my_season = MySeason.create_or_find_by(human: current_human, season:)
       if params.require(:season).require(:watched)
         my_season.update!(
-          watched_episode_numbers: season.episodes.order(episode_number: :asc).pluck(:episode_number),
-          watched: true # TODO: remove me
+          watched_episode_numbers: season.episodes.order(episode_number: :asc).pluck(:episode_number)
         )
       else
         my_season.update!(
-          watched_episode_numbers: [],
-          watched: false # TODO: remove me
+          watched_episode_numbers: []
         )
       end
 

--- a/app/models/my_season.rb
+++ b/app/models/my_season.rb
@@ -8,4 +8,8 @@ class MySeason < ApplicationRecord
   def reviews
     SeasonReview.where(season:, author: human)
   end
+
+  def watched?
+    watched_episode_numbers.uniq.sort == season.episodes.pluck(:episode_number).uniq.sort
+  end
 end

--- a/app/models/my_show.rb
+++ b/app/models/my_show.rb
@@ -19,10 +19,11 @@ class MyShow < ApplicationRecord
                           .joins(:season)
                           .where(
                             human:,
-                            season: { show: },
-                            watched: true
-                          ).joins(:season)
-                          .maximum(:season_number)
+                            season: { show: }
+                          )
+                          .select(&:watched?)
+                          .map(&:season_number)
+                          .max
 
     most_recent_released = show.seasons.maximum(:season_number)
 

--- a/app/serializers/my_season_serializer.rb
+++ b/app/serializers/my_season_serializer.rb
@@ -18,7 +18,7 @@ class MySeasonSerializer < Oj::Serializer
 
   def your_relationship
     {
-      watched: my_season.watched
+      watched: my_season.watched?
     }
   end
 

--- a/db/migrate/20230107211737_drop_watched_column_from_my_season.rb
+++ b/db/migrate/20230107211737_drop_watched_column_from_my_season.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# We don't need this column anymore now that we have watched_episode_numbers
+class DropWatchedColumnFromMySeason < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :my_seasons,
+                  :watched,
+                  :boolean,
+                  default: false,
+                  null: false,
+                  comment: "Did the human watch this season yet?"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_07_201736) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_07_211737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,7 +86,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_07_201736) do
   create_table "my_seasons", force: :cascade do |t|
     t.bigint "human_id", null: false, comment: "Which human saved this season"
     t.bigint "season_id", null: false, comment: "Which season did this human save"
-    t.boolean "watched", default: false, null: false, comment: "Did the human watch this season yet?"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "watched_episode_numbers", default: [], null: false, comment: "Which episodes has this person watched?", array: true


### PR DESCRIPTION
We can now derive that info from the watched_episode_numbers column, and having it in both places means we need to worry about keeping them in sync with each other.