### PR TITLE
Refresh shows asynchronously

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,5 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "dry-struct"
 
 gem "bugsnag"
+
+gem "sucker_punch"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.11.0)
     strscan (3.0.4)
+    sucker_punch (3.1.0)
+      concurrent-ruby (~> 1.0)
     thor (1.2.1)
     timeout (0.3.0)
     tzinfo (2.0.5)
@@ -277,6 +279,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
+  sucker_punch
   tzinfo-data
   vite_rails
 

--- a/app/jobs/refresh_show_job.rb
+++ b/app/jobs/refresh_show_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# job to invoke the refresh show service asynchronously
+# which is nice because if one show fails to refresh, that won't block all of the others
+class RefreshShowJob
+  include SuckerPunch::Job
+
+  def perform(show_id)
+    show = Show.find(show_id)
+    logger.info "Refreshing show #{show.slug}"
+
+    show.refresh!
+  end
+end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -33,4 +33,8 @@ class Show < ApplicationRecord
   def refresh!
     RefreshShow.call(self)
   end
+
+  def refresh_async
+    RefreshShowJob.perform_async(id)
+  end
 end

--- a/config/initializers/sucker_punch.rb
+++ b/config/initializers/sucker_punch.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+SuckerPunch.exception_handler = lambda { |ex, klass, args|
+  Rails.logger.error <<~MSG.chomp
+    SuckerPunch job failed - klass=#{klass} args=#{args.inspect}
+
+
+    #{ex.inspect}
+
+    #{ex.backtrace&.join("\n")}
+  MSG
+
+  Bugsnag.notify(ex)
+}

--- a/lib/tasks/tmdb.rake
+++ b/lib/tasks/tmdb.rake
@@ -17,17 +17,23 @@ namespace :tmdb do
   # Run daily via https://dashboard.heroku.com/apps/seasoning/scheduler
   task refresh_shows: :environment do
     Show.needs_refreshing.find_each do |show|
-      puts "Refreshing #{show.slug}"
-      show.refresh!
+      puts "Refreshing #{show.slug} asynchronously"
+      show.refresh_async
     end
+
+    puts "Waiting for all jobs to finish"
+    SuckerPunch::Queue.wait
   end
 
   # Available to run manually if I make changes to the import/refresh flow and want
   # to kick off a full refresh to confirm it's still working
   task refresh_all_shows: :environment do
     Show.all.find_each do |show|
-      puts "Refreshing #{show.slug}"
-      show.refresh!
+      puts "Refreshing #{show.slug} asynchronously"
+      show.refresh_async
     end
+
+    puts "Waiting for all jobs to finish"
+    SuckerPunch::Queue.wait
   end
 end


### PR DESCRIPTION
Right now the night court remaking is failing to refresh, and that's blocking other things from refreshing. So let's pop it in a background job so that it can fail without blocking other things.