### PR TITLE
Fix episode refresh edge case

### DIFF
--- a/app/services/refresh_episodes.rb
+++ b/app/services/refresh_episodes.rb
@@ -4,10 +4,10 @@ RefreshEpisodes = lambda do |show, season|
   data = TMDB::Client.new.season_details(show.tmdb_tv_id, season.season_number)
 
   data.episodes.each do |tmdb_episode|
-    episode = season.episodes.find_or_initialize_by(tmdb_id: tmdb_episode.id)
+    episode = season.episodes.find_or_initialize_by(episode_number: tmdb_episode.episode_number)
     episode.name = tmdb_episode.name
     episode.still_path = tmdb_episode.still_path
-    episode.episode_number = tmdb_episode.episode_number
+    episode.tmdb_id = tmdb_episode.id
     episode.save!
   end
 end


### PR DESCRIPTION
The night court (2023) refresh is currently failing because, it seems, they've re-arranged the episode order since I first imported it. That's fair enough given that they haven't even aired yet.

With this change, we'll rewrite the existing records to reflect whatever order tmdb says they're in now.

This isn't a totally perfect solution... if they delete an episode after seasoning has imported it, seasoning won't know to delete it... but perhaps we'll cross that bridge when we come to it.