### PR TITLE
Sort shows by title _without_ article

### DIFF
--- a/app/controllers/api/your_shows_controller.rb
+++ b/app/controllers/api/your_shows_controller.rb
@@ -10,7 +10,14 @@ module API
                  .my_shows
                  .joins(:show)
                  .then { |relation| search(relation) }
-                 .order(status: :asc, title: :asc)
+                 .order(
+                   Arel.sql(
+                     <<~SQL.squish
+                       status asc,
+                       regexp_replace(title, '^(The|A)\s', '', 'i')
+                     SQL
+                   )
+                 )
 
       render json: {
         your_shows: MyShowSerializer.many(my_shows)

--- a/app/javascript/pages/ChangelogPage.tsx
+++ b/app/javascript/pages/ChangelogPage.tsx
@@ -7,6 +7,7 @@ const changelog = `
 
   But here's some highlights of when things happened.
 
+  1. **February 15, 2023** — Ignore "The" and "A" at start of titles when sorting shows
   1. **February 11, 2023** — Display show first aired year on search page
   1. **February 11, 2023** — Add more info links to TMDB
   1. **February 11, 2023** — Some restyling with Tailwind

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -26,6 +26,16 @@ class Show < ApplicationRecord
     where(tmdb_next_refresh_at: nil).or(where(tmdb_next_refresh_at: ..(Time.zone.now)))
   }
 
+  scope :alphabetical, lambda {
+    order(
+      Arel.sql(
+        <<~SQL.squish
+          regexp_replace(title, '^(The|A)\s', '', 'i')
+        SQL
+      )
+    )
+  }
+
   def poster
     Poster.new(tmdb_poster_path)
   end

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -17,7 +17,7 @@ class ProfileSerializer < Oj::Serializer
   end
 
   def currently_watching
-    shows = profile.human.shows.where(my_shows: { status: "currently_watching" }).order(title: :asc)
+    shows = profile.human.shows.where(my_shows: { status: "currently_watching" }).alphabetical
 
     ShowSerializer.many(shows)
   end


### PR DESCRIPTION
I hope I'm using the word "article" correctly

but this makes titles like "The Last Of Us" sort as if the title was "Last of Us", which I think is chiller.