### PR TITLE
Fix time zone bug

### DIFF
--- a/app/javascript/components/AirDate.tsx
+++ b/app/javascript/components/AirDate.tsx
@@ -8,7 +8,7 @@ export const AirDate: FunctionComponent<Props> = ({ date: dateStr }: Props) => {
   if (dateStr) {
     const date: Date = new Date(dateStr)
 
-    return <>{date.toLocaleDateString()}</>
+    return <>{date.toLocaleDateString(undefined, { timeZone: "UTC" })}</>
   } else {
     return <>&mdash;</>
   }


### PR DESCRIPTION
Episode air dates were off by a day 😬

That's because the date string looks like "2023-02-21", and if you do

```js
new Date("2023-02-21")
```

Then JS will interpret that as midnight UTC, which happens to be 19:00 the day before in New York, so if you're in New York and you format that timestamp as a date, it will say 02/20/2023.

The fix is to tell Date to use the UTC time zone when formatting rather than assuming I want it to use the system time zone.