### PR TITLE
Fix: showing flicker of incorrect copy on homepage

### DIFF
--- a/app/javascript/components/YourShowsList.tsx
+++ b/app/javascript/components/YourShowsList.tsx
@@ -99,9 +99,6 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
       },
     })
       .then((response) => {
-        globalSetLoading(false)
-        setLoading(false)
-
         if (response.ok) {
           return response.json()
         } else {
@@ -110,6 +107,8 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
       })
       .then((data: YourShows) => {
         setShows(data.your_shows)
+        setLoading(false)
+        globalSetLoading(false)
       })
   }, [titleQueryValue, statusesFilterValue.join("-")])
 


### PR DESCRIPTION
If we set loading to false before we set the data then it's possible for react to redraw the page for a split second and say "No shows yet..." even though there are and they're going to show up in a split second, which kinda sucks.

This suggests the modeling of the state for this page is kind of wrong, but idc, this is a fine quick fix for now.