### PR TITLE
Improve new season checker

### DIFF
--- a/app/javascript/pages/ChangelogPage.tsx
+++ b/app/javascript/pages/ChangelogPage.tsx
@@ -7,6 +7,7 @@ const changelog = `
 
   But here's some highlights of when things happened.
 
+  1. **February 23, 2023** — Automatically toggle shows from "waiting for more" to "next up" _only when there is a new episode available to watch_, not just when the season is announced.
   1. **February 23, 2023** — Add some animation to the global loading ribbon
   1. **February 23, 2023** — Show future episode air dates in a fainter gray text color in episodes list on season page
   1. **February 21, 2023** — Fix bug where episode air dates could be off by a day

--- a/app/models/my_show.rb
+++ b/app/models/my_show.rb
@@ -25,7 +25,11 @@ class MyShow < ApplicationRecord
                           .map { |my_season| my_season.season.season_number }
                           .max
 
-    most_recent_released = show.seasons.maximum(:season_number)
+    most_recent_released = show
+                           .seasons
+                           .select { |season| season.episodes.any?(&:available?) }
+                           .map(&:season_number)
+                           .max
 
     most_recent_watched.present? && most_recent_watched < most_recent_released
   end


### PR DESCRIPTION
Automatically toggle shows from "waiting for more" to "next up" _only when there is a new episode available to watch_, not just when the season is announced.

This seems more intuitive to me.