### PR TITLE
Update rubocop flag

### DIFF
--- a/exe/fix-lints
+++ b/exe/fix-lints
@@ -3,4 +3,4 @@
 set -ex
 
 npx prettier --write .
-bin/rubocop --auto-correct-all
+bin/rubocop --autocorrect-all


### PR DESCRIPTION
That one got deprecated and prints a warning now. Sure.