### PR TITLE
Add currently watching limit to settings

### DIFF
--- a/app/controllers/api/human_limits_controller.rb
+++ b/app/controllers/api/human_limits_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module API
+  # Exposes up-to-the-second info on this human's show limits
+  class HumanLimitsController < ApplicationController
+    def show
+      authorize! { current_human.present? }
+
+      render json: HumanLimitsSerializer.one(current_human)
+    end
+  end
+end

--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -20,7 +20,11 @@ module API
     private
 
     def settings_params
-      params.permit(:share_currently_watching, :default_review_visibility)
+      params.permit(
+        :currently_watching_limit,
+        :default_review_visibility,
+        :share_currently_watching
+      )
     end
   end
 end

--- a/app/javascript/components/ChooseShowStatusButton.tsx
+++ b/app/javascript/components/ChooseShowStatusButton.tsx
@@ -1,8 +1,14 @@
-import { displayMyShowStatus, updateMyShow } from "../helpers/my_shows"
+import {
+  atLimit,
+  displayMyShowStatus,
+  displayMyShowStatusLimit,
+  updateMyShow,
+} from "../helpers/my_shows"
 import { FunctionComponent, useContext } from "react"
-import { MyShowStatus, Show, YourRelationshipToShow, YourShow } from "../types"
+import { GuestContext, SetLoadingContext } from "../contexts"
+import { HumanLimits, MyShowStatus, Show, YourRelationshipToShow, YourShow } from "../types"
+import { loadData } from "../hooks"
 import { Select } from "./Select"
-import { SetLoadingContext } from "../contexts"
 
 const allStatuses: MyShowStatus[] = [
   "might_watch",
@@ -27,6 +33,22 @@ export const ChooseShowStatusButton: FunctionComponent<Props> = ({
   setYourShow,
 }: Props) => {
   const globalSetLoading = useContext(SetLoadingContext)
+  const guest = useContext(GuestContext)
+
+  const limits = loadData<HumanLimits>(
+    guest,
+    "/api/human-limits.json",
+    [yourRelationship.status],
+    globalSetLoading
+  )
+
+  if (limits.loading) {
+    return <p>Loading...</p>
+  }
+
+  if (!limits.data) {
+    throw new Error("Missing limits data")
+  }
 
   return (
     <Select
@@ -46,8 +68,8 @@ export const ChooseShowStatusButton: FunctionComponent<Props> = ({
     >
       {allStatuses.map((status) => {
         return (
-          <option key={status} value={status}>
-            {displayMyShowStatus(status)}
+          <option key={status} value={status} disabled={atLimit(status, limits.data)}>
+            {displayMyShowStatus(status)} {displayMyShowStatusLimit(status, limits.data)}
           </option>
         )
       })}

--- a/app/javascript/helpers/my_shows.ts
+++ b/app/javascript/helpers/my_shows.ts
@@ -1,4 +1,4 @@
-import { Episode, MyShowStatus, Season, Show } from "../types"
+import { Episode, HumanLimits, MyShowStatus, Season, Show } from "../types"
 
 export const displayMyShowStatus = (status: MyShowStatus): string => {
   return {
@@ -9,6 +9,25 @@ export const displayMyShowStatus = (status: MyShowStatus): string => {
     waiting_for_more: "Waiting for more",
     finished: "Finished",
   }[status]
+}
+
+export const displayMyShowStatusLimit = (status: MyShowStatus, limits: HumanLimits): string => {
+  if (atLimit(status, limits)) {
+    return "(At limit!)"
+  } else {
+    return ""
+  }
+}
+
+export const atLimit = (status: MyShowStatus, limits: HumanLimits): boolean => {
+  if (status === "currently_watching") {
+    return !!(
+      limits.currently_watching_limit.max &&
+      limits.currently_watching_limit.current >= limits.currently_watching_limit.max
+    )
+  } else {
+    return false
+  }
 }
 
 export const updateMyShow = (

--- a/app/javascript/pages/ChangelogPage.tsx
+++ b/app/javascript/pages/ChangelogPage.tsx
@@ -7,6 +7,7 @@ const changelog = `
 
   But here's some highlights of when things happened.
 
+  1. **April 17, 2023** — Humans can optionally set a limit on how many shows they are currently watching
   1. **March 31, 2023** — Show "last refreshed at" show data on season page and episode page
   1. **February 23, 2023** — Automatically toggle shows from "waiting for more" to "next up" _only when there is a new episode available to watch_, not just when the season is announced.
   1. **February 23, 2023** — Add some animation to the global loading ribbon

--- a/app/javascript/pages/SettingsPage.tsx
+++ b/app/javascript/pages/SettingsPage.tsx
@@ -92,7 +92,7 @@ const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSetti
 
   return (
     <>
-      <div className="my-2">
+      <div className="my-6">
         <h2 className="text-xl">Profile page</h2>
         <Checkbox
           name="share-currently-watching"
@@ -109,7 +109,7 @@ const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSetti
         </label>
       </div>
 
-      <div className="my-2">
+      <div className="my-6">
         <h2 className="text-xl">Reviews</h2>
 
         <div>
@@ -130,6 +130,39 @@ const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSetti
           This is just a default for new reviews, you can pick another visibility on a
           review-by-review basis!
         </p>
+      </div>
+
+      <div className="my-6">
+        <h2 className="text-xl">Limits</h2>
+
+        <div>
+          <label>Currently watching limit</label>
+        </div>
+
+        <Select
+          value={settingsData.settings.currently_watching_limit || -1}
+          onChange={(event) => {
+            const value = event.target.value
+            if (parseInt(value) > 0) {
+              update({ currently_watching_limit: value })
+            } else {
+              update({ currently_watching_limit: null })
+            }
+          }}
+          disabled={currentlyUpdating}
+        >
+          <option value={-1}>None</option>
+          <option value={1}>1</option>
+          <option value={2}>2</option>
+          <option value={3}>3</option>
+          <option value={4}>4</option>
+          <option value={5}>5</option>
+          <option value={6}>6</option>
+          <option value={7}>7</option>
+          <option value={8}>8</option>
+          <option value={9}>9</option>
+          <option value={10}>10</option>
+        </Select>
       </div>
     </>
   )

--- a/app/javascript/types.ts
+++ b/app/javascript/types.ts
@@ -1,11 +1,21 @@
 export interface HumanSettings {
   share_currently_watching: boolean
   default_review_visibility: Visibility
+  currently_watching_limit: number | null
 }
 
 export interface Human {
   handle: string
   admin: boolean
+}
+
+interface Limit {
+  current: number
+  max: number | null
+}
+
+export interface HumanLimits {
+  currently_watching_limit: Limit
 }
 
 export interface AuthenticatedGuest {

--- a/app/models/human.rb
+++ b/app/models/human.rb
@@ -11,6 +11,7 @@ class Human < ApplicationRecord
   before_save ->(human) { human.email = human.email.to_s.strip.downcase.presence }
 
   validates :handle, exclusion: { in: RESERVED_WORDS, message: "%<value>s is reserved" }
+  validates :currently_watching_limit, numericality: { in: 1..10, allow_nil: true }
 
   def followers
     human_ids = Follow.where(followee_id: id).pluck(:follower_id)

--- a/app/serializers/human_limits_serializer.rb
+++ b/app/serializers/human_limits_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# What are the state of this person's limits
+# For example, if they want to watch no more than 4 shows at a time... how many are they currently watching?
+class HumanLimitsSerializer < Oj::Serializer
+  object_as :human
+
+  serializer_attributes :currently_watching_limit
+
+  def currently_watching_limit
+    {
+      current: human.shows.where(my_shows: { status: "currently_watching" }).count,
+      max: human.currently_watching_limit
+    }
+  end
+end

--- a/app/serializers/settings_serializer.rb
+++ b/app/serializers/settings_serializer.rb
@@ -3,7 +3,8 @@
 # Serializes someone's settings
 class SettingsSerializer < Oj::Serializer
   attributes(
-    :share_currently_watching,
-    :default_review_visibility
+    :currently_watching_limit,
+    :default_review_visibility,
+    :share_currently_watching
   )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       resources :season_reviews, only: %i[create index], path: "/season-reviews"
       resource :season_review, only: %i[show destroy], path: "/season-review"
       resource :admin, only: %i[show]
+      resource :human_limits, only: %i[show], path: "/human-limits", controller: "human_limits"
     end
   end
 

--- a/db/migrate/20230417145901_add_currently_watching_limit_to_humans.rb
+++ b/db/migrate/20230417145901_add_currently_watching_limit_to_humans.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This new setting will support a new feature where humans can set their
+# cap on how many shows they want to be watching at once
+#
+# Because... I watch too many shows and feel guilty about it!
+class AddCurrentlyWatchingLimitToHumans < ActiveRecord::Migration[7.0]
+  def change
+    change_table :humans do |t|
+      t.integer :currently_watching_limit,
+                null: true,
+                comment: "How many shows, at most, does this human want to watch at once?"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_08_024401) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_17_145901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_08_024401) do
     t.boolean "share_currently_watching", default: true, null: false, comment: "Whether or not to publicly display your currently watching list on the profile page"
     t.enum "default_review_visibility", default: "anybody", null: false, comment: "Lets people specify who they generally want to share their reviews with, to save them some clicking", enum_type: "visibility"
     t.boolean "admin", default: false, null: false, comment: "Gives humans some extra abilities to see things like the admin stats page"
+    t.integer "currently_watching_limit", comment: "How many shows, at most, does this human want to watch at once?"
     t.index ["email"], name: "humans_email_unique", unique: true
     t.index ["handle"], name: "humans_handle_unique", unique: true
   end


### PR DESCRIPTION
This lets you choose how many shows you want to watch at once to perhaps help you prioritize and take control of your screen time.

Setting UX:

<img width="726" alt="Screenshot 2023-04-17 at 12 14 01" src="https://user-images.githubusercontent.com/1421211/232546598-00fab626-1afb-4647-a43d-c5f23b75b39c.png">

Limit UX:

<img width="809" alt="Screenshot 2023-04-17 at 12 14 18" src="https://user-images.githubusercontent.com/1421211/232546663-0835a27b-c40a-40e4-8edc-29f24b4acc53.png">
