### PR TITLE
Fix mergeabot config

### DIFF
--- a/.github/workflows/mergeabot.yml
+++ b/.github/workflows/mergeabot.yml
@@ -2,7 +2,7 @@ name: Mergeabot
 
 on:
   schedule:
-    cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
   pull_request:
 


### PR DESCRIPTION
Hm, in https://github.com/maxjacobson/seasoning/pull/1109 I copied the [example](https://github.com/freckle/mergeabot-action#complete-example) from their README, but maybe it had an error, because I see this:
https://github.com/maxjacobson/seasoning/actions/runs/5093441480/workflow

> **Invalid workflow file**
>
> `schedule` accepts a list of one or more maps with the `cron` key set

Looking at the docs for `schedule`, it looks like this is supposed to be a list, which is consistent with what the error message says. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule