### PR TITLE
Update show refresh interval logic

### DIFF
--- a/app/javascript/pages/ChangelogPage.tsx
+++ b/app/javascript/pages/ChangelogPage.tsx
@@ -7,6 +7,7 @@ const changelog = `
 
   But here's some highlights of when things happened.
 
+  1. **June 29, 2023** — Update data refresh so that shows which are complete will refresh once per week, and ongoing shows will refresh daily
   1. **June 25, 2023** — Blockquotes in rendered markdown are now styled as blockquotes, with a left border
   1. **June 25, 2023** — Some more spacing between paragraphs in rendered markdown
   1. **May 22, 2023** — Basic pagination on the "Your shows" page to only show 10 shows at a time

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -3,8 +3,6 @@
 # A TV show!
 # Data is mostly from the movie database
 class Show < ApplicationRecord
-  REFRESH_INTERVAL = 2.days
-
   before_create lambda {
     slug = nil
     n = nil
@@ -35,6 +33,15 @@ class Show < ApplicationRecord
       )
     )
   }
+
+  def self.refresh_interval(tmdb_show)
+    if tmdb_show.in_production
+      # N.B. the refresh happens once per day, so this just means it'll get refreshed on the next day too
+      1.hour.from_now
+    else
+      1.week.from_now
+    end
+  end
 
   def poster
     Poster.new(tmdb_poster_path)

--- a/app/services/find_or_create_show.rb
+++ b/app/services/find_or_create_show.rb
@@ -7,7 +7,7 @@ FindOrCreateShow = lambda { |tmdb_show|
     title: tmdb_show.name,
     tmdb_tv_id: tmdb_show.id,
     tmdb_poster_path: tmdb_show.poster_path,
-    tmdb_next_refresh_at: Show::REFRESH_INTERVAL.from_now,
+    tmdb_next_refresh_at: Show.refresh_interval(tmdb_show),
     tmdb_last_refreshed_at: Time.zone.now
   )
 

--- a/app/services/refresh_show.rb
+++ b/app/services/refresh_show.rb
@@ -6,7 +6,7 @@ RefreshShow = lambda { |show|
 
     show.update!(
       tmdb_poster_path: details.poster_path,
-      tmdb_next_refresh_at: Show::REFRESH_INTERVAL.from_now,
+      tmdb_next_refresh_at: Show.refresh_interval(details),
       first_air_date: details.first_air_date,
       tmdb_last_refreshed_at: Time.zone.now
     )


### PR DESCRIPTION
For actively airing shows, the data can change on a day-by-day basis, so we want to have up-to-date info. But it seems kind of crazy to keep refreshing The Wire every day. We probably don't even need to refresh it weekly but I guess it doesn't hurt.