### PR TITLE
use semicolons in javascript again

### DIFF
--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,5 +1,4 @@
 # https://prettier.io/docs/en/configuration.html
-semi = false
 printWidth = 100
 plugins = [
   "prettier-plugin-tailwindcss"

--- a/app/javascript/App.tsx
+++ b/app/javascript/App.tsx
@@ -1,45 +1,45 @@
-import "./App.css"
+import "./App.css";
 
-import { BrowserRouter, Link, Route, Routes, useNavigate, useSearchParams } from "react-router-dom"
-import { FunctionComponent, useState } from "react"
-import { Guest, Show } from "./types"
-import { GuestContext, SetLoadingContext } from "./contexts"
-import { AdminPage } from "./pages/AdminPage"
-import { ChangelogPage } from "./pages/ChangelogPage"
-import { CreditsPage } from "./pages/CreditsPage"
-import { EpisodePage } from "./pages/EpisodePage"
-import { HomePage } from "./pages/HomePage"
-import { ImportShowPage } from "./pages/ImportShowPage"
-import { LoadingRibbon } from "./components/LoadingRibbon"
-import LogoWithName from "./images/logo-with-name.svg"
-import { NewSeasonReviewPage } from "./pages/NewSeasonReviewPage"
-import { NotFoundPage } from "./pages/NotFoundPage"
-import { ProfileFollowersPage } from "./pages/ProfileFollowersPage"
-import { ProfileFollowingPage } from "./pages/ProfileFollowingPage"
-import { ProfilePage } from "./pages/ProfilePage"
-import { ProfileReviewsPage } from "./pages/ProfileReviewsPage"
-import { RedeemMagicLinkPage } from "./pages/RedeemMagicLinkPage"
-import { ReviewsFeedPage } from "./pages/ReviewsFeedPage"
-import { RoadmapPage } from "./pages/RoadmapPage"
-import { SearchResultsPage } from "./pages/SearchResultsPage"
-import { SeasonPage } from "./pages/SeasonPage"
-import { SeasonReviewPage } from "./pages/SeasonReviewPage"
-import { SettingsPage } from "./pages/SettingsPage"
-import { ShowPage } from "./pages/ShowPage"
-import { ShowSearchBar } from "./components/ShowSearchBar"
-import { YourShowsPage } from "./pages/YourShowsPage"
+import { BrowserRouter, Link, Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
+import { FunctionComponent, useState } from "react";
+import { Guest, Show } from "./types";
+import { GuestContext, SetLoadingContext } from "./contexts";
+import { AdminPage } from "./pages/AdminPage";
+import { ChangelogPage } from "./pages/ChangelogPage";
+import { CreditsPage } from "./pages/CreditsPage";
+import { EpisodePage } from "./pages/EpisodePage";
+import { HomePage } from "./pages/HomePage";
+import { ImportShowPage } from "./pages/ImportShowPage";
+import { LoadingRibbon } from "./components/LoadingRibbon";
+import LogoWithName from "./images/logo-with-name.svg";
+import { NewSeasonReviewPage } from "./pages/NewSeasonReviewPage";
+import { NotFoundPage } from "./pages/NotFoundPage";
+import { ProfileFollowersPage } from "./pages/ProfileFollowersPage";
+import { ProfileFollowingPage } from "./pages/ProfileFollowingPage";
+import { ProfilePage } from "./pages/ProfilePage";
+import { ProfileReviewsPage } from "./pages/ProfileReviewsPage";
+import { RedeemMagicLinkPage } from "./pages/RedeemMagicLinkPage";
+import { ReviewsFeedPage } from "./pages/ReviewsFeedPage";
+import { RoadmapPage } from "./pages/RoadmapPage";
+import { SearchResultsPage } from "./pages/SearchResultsPage";
+import { SeasonPage } from "./pages/SeasonPage";
+import { SeasonReviewPage } from "./pages/SeasonReviewPage";
+import { SettingsPage } from "./pages/SettingsPage";
+import { ShowPage } from "./pages/ShowPage";
+import { ShowSearchBar } from "./components/ShowSearchBar";
+import { YourShowsPage } from "./pages/YourShowsPage";
 
 interface Props {
-  initialGuest: Guest
+  initialGuest: Guest;
 }
 
 const App: FunctionComponent<Props> = ({ initialGuest }: Props) => {
-  const [guest, setGuest] = useState<Guest>(initialGuest)
-  const [loading, setLoading] = useState(false)
-  const [searchResults, setSearchResults] = useState<Show[] | null>(null)
-  const navigate = useNavigate()
-  const [searchParams, setSearchParams] = useSearchParams()
-  const searchQuery = searchParams.get("q") || ""
+  const [guest, setGuest] = useState<Guest>(initialGuest);
+  const [loading, setLoading] = useState(false);
+  const [searchResults, setSearchResults] = useState<Show[] | null>(null);
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchQuery = searchParams.get("q") || "";
 
   return (
     <>
@@ -75,9 +75,9 @@ const App: FunctionComponent<Props> = ({ initialGuest }: Props) => {
                       href="#"
                       onClick={() => {
                         if (confirm("Log out?")) {
-                          localStorage.clear()
-                          setGuest({ authenticated: false })
-                          navigate("/")
+                          localStorage.clear();
+                          setGuest({ authenticated: false });
+                          navigate("/");
                         }
                       }}
                     >
@@ -151,13 +151,13 @@ const App: FunctionComponent<Props> = ({ initialGuest }: Props) => {
         </SetLoadingContext.Provider>
       </GuestContext.Provider>
     </>
-  )
-}
+  );
+};
 
 export const AppWithRouter: FunctionComponent<Props> = (props) => {
   return (
     <BrowserRouter>
       <App {...props} />
     </BrowserRouter>
-  )
-}
+  );
+};

--- a/app/javascript/components/AddShowButton.tsx
+++ b/app/javascript/components/AddShowButton.tsx
@@ -1,11 +1,11 @@
-import { Show, YourShow } from "../types"
-import { Button } from "./Button"
-import { FunctionComponent } from "react"
+import { Show, YourShow } from "../types";
+import { Button } from "./Button";
+import { FunctionComponent } from "react";
 
 interface Props {
-  show: Show
-  token: string
-  setYourShow: (yourShow: YourShow) => void
+  show: Show;
+  token: string;
+  setYourShow: (yourShow: YourShow) => void;
 }
 
 export const AddShowButton: FunctionComponent<Props> = ({ show, token, setYourShow }: Props) => {
@@ -23,17 +23,17 @@ export const AddShowButton: FunctionComponent<Props> = ({ show, token, setYourSh
             },
           }),
           method: "POST",
-        })
+        });
 
         if (response.ok) {
-          const data: { your_show: YourShow } = await response.json()
-          setYourShow(data.your_show)
+          const data: { your_show: YourShow } = await response.json();
+          setYourShow(data.your_show);
         } else {
-          throw new Error("Could not add show")
+          throw new Error("Could not add show");
         }
       }}
     >
       Add
     </Button>
-  )
-}
+  );
+};

--- a/app/javascript/components/AirDate.tsx
+++ b/app/javascript/components/AirDate.tsx
@@ -1,21 +1,21 @@
-import { FunctionComponent } from "react"
+import { FunctionComponent } from "react";
 
 interface Props {
-  date: string | null
-  available: boolean
+  date: string | null;
+  available: boolean;
 }
 
 export const AirDate: FunctionComponent<Props> = ({ date: dateStr, available }: Props) => {
   if (dateStr) {
-    const date: Date = new Date(dateStr)
-    const dateFormatted = date.toLocaleDateString(undefined, { timeZone: "UTC" })
+    const date: Date = new Date(dateStr);
+    const dateFormatted = date.toLocaleDateString(undefined, { timeZone: "UTC" });
 
     if (available) {
-      return <span>{dateFormatted}</span>
+      return <span>{dateFormatted}</span>;
     } else {
-      return <span className="text-slate-400">{dateFormatted}</span>
+      return <span className="text-slate-400">{dateFormatted}</span>;
     }
   } else {
-    return <>&mdash;</>
+    return <>&mdash;</>;
   }
-}
+};

--- a/app/javascript/components/Button.tsx
+++ b/app/javascript/components/Button.tsx
@@ -1,4 +1,4 @@
-type Props = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "className">
+type Props = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "className">;
 
 export const Button = (props: Props) => {
   return (
@@ -8,5 +8,5 @@ export const Button = (props: Props) => {
     >
       {props.value || props.children}
     </button>
-  )
-}
+  );
+};

--- a/app/javascript/components/Checkbox.tsx
+++ b/app/javascript/components/Checkbox.tsx
@@ -2,9 +2,9 @@ type Props = Omit<
   React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
   "type"
 > & {
-  inputRef?: React.LegacyRef<HTMLInputElement>
-}
+  inputRef?: React.LegacyRef<HTMLInputElement>;
+};
 
 export const Checkbox = (props: Props) => {
-  return <input type="checkbox" {...props} className="text-yellow-500" ref={props.inputRef} />
-}
+  return <input type="checkbox" {...props} className="text-yellow-500" ref={props.inputRef} />;
+};

--- a/app/javascript/components/ChooseShowStatusButton.tsx
+++ b/app/javascript/components/ChooseShowStatusButton.tsx
@@ -3,12 +3,12 @@ import {
   displayMyShowStatus,
   displayMyShowStatusLimit,
   updateMyShow,
-} from "../helpers/my_shows"
-import { FunctionComponent, useContext } from "react"
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { HumanLimits, MyShowStatus, Show, YourRelationshipToShow, YourShow } from "../types"
-import { loadData } from "../hooks"
-import { Select } from "./Select"
+} from "../helpers/my_shows";
+import { FunctionComponent, useContext } from "react";
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { HumanLimits, MyShowStatus, Show, YourRelationshipToShow, YourShow } from "../types";
+import { loadData } from "../hooks";
+import { Select } from "./Select";
 
 const allStatuses: MyShowStatus[] = [
   "might_watch",
@@ -17,13 +17,13 @@ const allStatuses: MyShowStatus[] = [
   "stopped_watching",
   "waiting_for_more",
   "finished",
-]
+];
 
 interface Props {
-  show: Show
-  yourRelationship: YourRelationshipToShow
-  token: string
-  setYourShow: (yourShow: YourShow) => void
+  show: Show;
+  yourRelationship: YourRelationshipToShow;
+  token: string;
+  setYourShow: (yourShow: YourShow) => void;
 }
 
 export const ChooseShowStatusButton: FunctionComponent<Props> = ({
@@ -32,37 +32,37 @@ export const ChooseShowStatusButton: FunctionComponent<Props> = ({
   yourRelationship,
   setYourShow,
 }: Props) => {
-  const globalSetLoading = useContext(SetLoadingContext)
-  const guest = useContext(GuestContext)
+  const globalSetLoading = useContext(SetLoadingContext);
+  const guest = useContext(GuestContext);
 
   const limits = loadData<HumanLimits>(
     guest,
     "/api/human-limits.json",
     [yourRelationship.status],
     globalSetLoading,
-  )
+  );
 
   if (limits.loading) {
-    return <p>Loading...</p>
+    return <p>Loading...</p>;
   }
 
   if (!limits.data) {
-    throw new Error("Missing limits data")
+    throw new Error("Missing limits data");
   }
 
   return (
     <Select
       value={yourRelationship.status}
       onChange={async (event) => {
-        globalSetLoading(true)
-        const response = await updateMyShow(show, token, { show: { status: event.target.value } })
-        globalSetLoading(false)
+        globalSetLoading(true);
+        const response = await updateMyShow(show, token, { show: { status: event.target.value } });
+        globalSetLoading(false);
 
         if (response.ok) {
-          const data: YourShow = await response.json()
-          setYourShow(data)
+          const data: YourShow = await response.json();
+          setYourShow(data);
         } else {
-          throw new Error("Could not update status of show")
+          throw new Error("Could not update status of show");
         }
       }}
     >
@@ -71,8 +71,8 @@ export const ChooseShowStatusButton: FunctionComponent<Props> = ({
           <option key={status} value={status} disabled={atLimit(status, limits.data)}>
             {displayMyShowStatus(status)} {displayMyShowStatusLimit(status, limits.data)}
           </option>
-        )
+        );
       })}
     </Select>
-  )
-}
+  );
+};

--- a/app/javascript/components/GetStarted.tsx
+++ b/app/javascript/components/GetStarted.tsx
@@ -1,21 +1,21 @@
-import { useContext, useEffect, useState } from "react"
-import { Button } from "./Button"
-import { SetLoadingContext } from "../contexts"
-import { TextField } from "./TextField"
-import { YouTubeVideo } from "./YouTubeVideo"
+import { useContext, useEffect, useState } from "react";
+import { Button } from "./Button";
+import { SetLoadingContext } from "../contexts";
+import { TextField } from "./TextField";
+import { YouTubeVideo } from "./YouTubeVideo";
 
 export const GetStarted = () => {
-  const [email, setEmail] = useState("")
-  const [loading, setLoading] = useState(false)
-  const [createdMagicLink, setCreatedMagicLink] = useState(false)
-  const globalSetLoading = useContext(SetLoadingContext)
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [createdMagicLink, setCreatedMagicLink] = useState(false);
+  const globalSetLoading = useContext(SetLoadingContext);
 
   useEffect(() => {
     if (!loading) {
-      return
+      return;
     }
 
-    globalSetLoading(true)
+    globalSetLoading(true);
     fetch("/api/magic-links.json", {
       headers: {
         "Content-Type": "application/json",
@@ -24,19 +24,19 @@ export const GetStarted = () => {
       method: "POST",
     })
       .then((response) => {
-        globalSetLoading(false)
-        setLoading(false)
+        globalSetLoading(false);
+        setLoading(false);
 
         if (response.ok) {
-          return response.json()
+          return response.json();
         } else {
-          throw new Error("Could not create magic link")
+          throw new Error("Could not create magic link");
         }
       })
       .then(() => {
-        setCreatedMagicLink(true)
-      })
-  }, [loading])
+        setCreatedMagicLink(true);
+      });
+  }, [loading]);
 
   if (createdMagicLink) {
     return (
@@ -44,7 +44,7 @@ export const GetStarted = () => {
         <h2>Nice!</h2>
         <p>Check your email for a link to log in to Seasoning!</p>
       </div>
-    )
+    );
   } else {
     return (
       <>
@@ -74,8 +74,8 @@ export const GetStarted = () => {
           <div>
             <form
               onSubmit={(e) => {
-                e.preventDefault()
-                setLoading(true)
+                e.preventDefault();
+                setLoading(true);
               }}
             >
               <TextField
@@ -96,6 +96,6 @@ export const GetStarted = () => {
           </div>
         </div>
       </>
-    )
+    );
   }
-}
+};

--- a/app/javascript/components/GoHome.tsx
+++ b/app/javascript/components/GoHome.tsx
@@ -1,5 +1,5 @@
-import { FunctionComponent } from "react"
-import { Link } from "react-router-dom"
+import { FunctionComponent } from "react";
+import { Link } from "react-router-dom";
 
 export const GoHome: FunctionComponent<Record<string, never>> = () => {
   return (
@@ -8,5 +8,5 @@ export const GoHome: FunctionComponent<Record<string, never>> = () => {
         <Link to="/">Go home</Link>
       </p>
     </>
-  )
-}
+  );
+};

--- a/app/javascript/components/LoadingRibbon.tsx
+++ b/app/javascript/components/LoadingRibbon.tsx
@@ -1,3 +1,3 @@
 export const LoadingRibbon = () => {
-  return <div className="loading-ribbon absolute left-0 top-0 h-2.5 bg-slate-500" />
-}
+  return <div className="loading-ribbon absolute left-0 top-0 h-2.5 bg-slate-500" />;
+};

--- a/app/javascript/components/Markdown.tsx
+++ b/app/javascript/components/Markdown.tsx
@@ -1,9 +1,9 @@
-import { FunctionComponent } from "react"
-import gfm from "remark-gfm"
-import ReactMarkdown from "react-markdown"
+import { FunctionComponent } from "react";
+import gfm from "remark-gfm";
+import ReactMarkdown from "react-markdown";
 
 interface Props {
-  markdown: string
+  markdown: string;
 }
 
 export const Markdown: FunctionComponent<Props> = ({ markdown }: Props) => {
@@ -13,5 +13,5 @@ export const Markdown: FunctionComponent<Props> = ({ markdown }: Props) => {
         {markdown}
       </ReactMarkdown>
     </>
-  )
-}
+  );
+};

--- a/app/javascript/components/MoreInfo.tsx
+++ b/app/javascript/components/MoreInfo.tsx
@@ -1,11 +1,11 @@
 type Props = {
-  url: string
-}
+  url: string;
+};
 
 export const MoreInfo = ({ url }: Props) => {
   return (
     <a href={url} target="_blank" className="my-3 inline-block">
       More info ↗️
     </a>
-  )
-}
+  );
+};

--- a/app/javascript/components/NoteToSelf.tsx
+++ b/app/javascript/components/NoteToSelf.tsx
@@ -1,16 +1,16 @@
-import { FunctionComponent, useContext, useEffect, useState } from "react"
+import { FunctionComponent, useContext, useEffect, useState } from "react";
 
-import { Button } from "./Button"
-import { Markdown } from "../components/Markdown"
-import { SetLoadingContext } from "../contexts"
-import { Textarea } from "./Textarea"
-import { updateMyShow } from "../helpers/my_shows"
-import { YourShow } from "../types"
+import { Button } from "./Button";
+import { Markdown } from "../components/Markdown";
+import { SetLoadingContext } from "../contexts";
+import { Textarea } from "./Textarea";
+import { updateMyShow } from "../helpers/my_shows";
+import { YourShow } from "../types";
 
 interface Props {
-  yourShow: YourShow
-  token: string
-  updateYourShow: (updatedYourShow: YourShow) => void
+  yourShow: YourShow;
+  token: string;
+  updateYourShow: (updatedYourShow: YourShow) => void;
 }
 
 export const NoteToSelf: FunctionComponent<Props> = ({
@@ -18,15 +18,15 @@ export const NoteToSelf: FunctionComponent<Props> = ({
   yourShow,
   updateYourShow,
 }: Props) => {
-  const [isEditing, setIsEditing] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [newNoteToSelf, setNewNoteToSelf] = useState("")
-  const globalSetLoading = useContext(SetLoadingContext)
+  const [isEditing, setIsEditing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [newNoteToSelf, setNewNoteToSelf] = useState("");
+  const globalSetLoading = useContext(SetLoadingContext);
 
   // I'll confess I am surprised that this is necessary...
   useEffect(() => {
-    setNewNoteToSelf(yourShow.your_relationship?.note_to_self || "")
-  }, [yourShow.show.slug])
+    setNewNoteToSelf(yourShow.your_relationship?.note_to_self || "");
+  }, [yourShow.show.slug]);
 
   if (yourShow.your_relationship?.note_to_self || isEditing) {
     return (
@@ -65,24 +65,24 @@ export const NoteToSelf: FunctionComponent<Props> = ({
           <div className="mt-4">
             <Button
               onClick={async () => {
-                globalSetLoading(true)
-                setLoading(true)
+                globalSetLoading(true);
+                setLoading(true);
 
                 const response = await updateMyShow(yourShow.show, token, {
                   show: {
                     note_to_self: newNoteToSelf,
                   },
-                })
+                });
 
-                setLoading(false)
-                globalSetLoading(false)
+                setLoading(false);
+                globalSetLoading(false);
 
                 if (response.ok) {
-                  const updated: YourShow = await response.json()
-                  updateYourShow(updated)
-                  setIsEditing(false)
+                  const updated: YourShow = await response.json();
+                  updateYourShow(updated);
+                  setIsEditing(false);
                 } else {
-                  throw new Error("Could not update note to self")
+                  throw new Error("Could not update note to self");
                 }
               }}
             >
@@ -99,8 +99,8 @@ export const NoteToSelf: FunctionComponent<Props> = ({
           </div>
         )}
       </div>
-    )
+    );
   } else {
-    return <Button onClick={() => setIsEditing(true)}>Write note to self</Button>
+    return <Button onClick={() => setIsEditing(true)}>Write note to self</Button>;
   }
-}
+};

--- a/app/javascript/components/Poster.tsx
+++ b/app/javascript/components/Poster.tsx
@@ -1,10 +1,10 @@
-import { FunctionComponent } from "react"
-import { Show } from "../types"
+import { FunctionComponent } from "react";
+import { Show } from "../types";
 
 interface Props {
-  url: string | null
-  show: Show
-  size: "small" | "large"
+  url: string | null;
+  show: Show;
+  size: "small" | "large";
 }
 
 export const Poster: FunctionComponent<Props> = ({ url, show, size }: Props) => (
@@ -18,4 +18,4 @@ export const Poster: FunctionComponent<Props> = ({ url, show, size }: Props) => 
       />
     )}
   </>
-)
+);

--- a/app/javascript/components/RemoveShowButton.tsx
+++ b/app/javascript/components/RemoveShowButton.tsx
@@ -1,10 +1,10 @@
-import { Button } from "./Button"
-import { Show } from "../types"
+import { Button } from "./Button";
+import { Show } from "../types";
 
 interface Props {
-  show: Show
-  token: string
-  onRemove: () => void
+  show: Show;
+  token: string;
+  onRemove: () => void;
 }
 
 export const RemoveShowButton = ({ show, token, onRemove }: Props) => {
@@ -16,7 +16,7 @@ export const RemoveShowButton = ({ show, token, onRemove }: Props) => {
             "Are you sure? This will lose track of your note to self and show status (but not reviews or which episodes you've seen)",
           )
         ) {
-          return
+          return;
         }
 
         // N.B. here we're specifying the show id rather than the my_shows id, because that's what we've expoed to the front-end
@@ -27,16 +27,16 @@ export const RemoveShowButton = ({ show, token, onRemove }: Props) => {
             "X-SEASONING-TOKEN": token,
           },
           method: "DELETE",
-        })
+        });
 
         if (response.ok) {
-          onRemove()
+          onRemove();
         } else {
-          throw new Error("Could not remove show")
+          throw new Error("Could not remove show");
         }
       }}
     >
       Remove
     </Button>
-  )
-}
+  );
+};

--- a/app/javascript/components/SeasonReviewSummary.tsx
+++ b/app/javascript/components/SeasonReviewSummary.tsx
@@ -1,18 +1,18 @@
-import { SeasonReview, Show } from "../types"
-import { FunctionComponent } from "react"
-import { Link } from "react-router-dom"
-import { Poster } from "./Poster"
-import { StarRating } from "../components/StarRating"
+import { SeasonReview, Show } from "../types";
+import { FunctionComponent } from "react";
+import { Link } from "react-router-dom";
+import { Poster } from "./Poster";
+import { StarRating } from "../components/StarRating";
 
 interface Props {
-  review: SeasonReview
-  show: Show
+  review: SeasonReview;
+  show: Show;
 }
 
 export const SeasonReviewSummary: FunctionComponent<Props> = ({ review, show }) => {
   const url = `/${review.author.handle}/shows/${show.slug}/${review.season.slug}${
     review.viewing === 1 ? "" : `/${review.viewing}`
-  }`
+  }`;
 
   return (
     <div>
@@ -30,5 +30,5 @@ export const SeasonReviewSummary: FunctionComponent<Props> = ({ review, show }) 
         </div>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/components/SeasonsList.tsx
+++ b/app/javascript/components/SeasonsList.tsx
@@ -1,11 +1,11 @@
-import { Guest, Show } from "../types"
-import { FunctionComponent } from "react"
-import { Link } from "react-router-dom"
-import { SeenSeasonCheckbox } from "./SeenSeasonCheckbox"
+import { Guest, Show } from "../types";
+import { FunctionComponent } from "react";
+import { Link } from "react-router-dom";
+import { SeenSeasonCheckbox } from "./SeenSeasonCheckbox";
 
 interface Props {
-  show: Show
-  guest: Guest
+  show: Show;
+  guest: Guest;
 }
 
 export const SeasonsList: FunctionComponent<Props> = ({ show, guest }: Props) => {
@@ -35,9 +35,9 @@ export const SeasonsList: FunctionComponent<Props> = ({ show, guest }: Props) =>
                 </td>
               )}
             </tr>
-          )
+          );
         })}
       </tbody>
     </table>
-  )
-}
+  );
+};

--- a/app/javascript/components/SeenEpisodeCheckbox.tsx
+++ b/app/javascript/components/SeenEpisodeCheckbox.tsx
@@ -1,15 +1,15 @@
-import { AuthenticatedGuest, Episode, Season, YourRelationshipToSeason } from "../types"
-import { FunctionComponent, useContext, useState } from "react"
-import { Checkbox } from "./Checkbox"
-import { SetLoadingContext } from "../contexts"
-import { updateMyEpisode } from "../helpers/my_shows"
+import { AuthenticatedGuest, Episode, Season, YourRelationshipToSeason } from "../types";
+import { FunctionComponent, useContext, useState } from "react";
+import { Checkbox } from "./Checkbox";
+import { SetLoadingContext } from "../contexts";
+import { updateMyEpisode } from "../helpers/my_shows";
 
 type Props = {
-  season: Season
-  episode: Episode
-  guest: AuthenticatedGuest
-  yourRelationshipToSeason: YourRelationshipToSeason
-}
+  season: Season;
+  episode: Episode;
+  guest: AuthenticatedGuest;
+  yourRelationshipToSeason: YourRelationshipToSeason;
+};
 
 export const SeenEpisodeCheckbox: FunctionComponent<Props> = ({
   guest,
@@ -19,31 +19,31 @@ export const SeenEpisodeCheckbox: FunctionComponent<Props> = ({
 }) => {
   const [hasSeen, setHasSeen] = useState(
     yourRelationshipToSeason.watched_episode_numbers.includes(episode.episode_number),
-  )
-  const [updating, setUpdating] = useState(false)
-  const setLoading = useContext(SetLoadingContext)
+  );
+  const [updating, setUpdating] = useState(false);
+  const setLoading = useContext(SetLoadingContext);
 
   return (
     <Checkbox
       checked={hasSeen}
       disabled={updating}
       onChange={async () => {
-        setLoading(true)
-        setUpdating(true)
+        setLoading(true);
+        setUpdating(true);
 
         const response = await updateMyEpisode(season, episode, guest.token, {
           seen: !hasSeen,
-        })
+        });
 
-        setLoading(false)
-        setUpdating(false)
+        setLoading(false);
+        setUpdating(false);
 
         if (response.ok) {
-          setHasSeen(!hasSeen)
+          setHasSeen(!hasSeen);
         } else {
-          throw new Error("Could not toggle seen status")
+          throw new Error("Could not toggle seen status");
         }
       }}
     />
-  )
-}
+  );
+};

--- a/app/javascript/components/SeenSeasonCheckbox.tsx
+++ b/app/javascript/components/SeenSeasonCheckbox.tsx
@@ -1,51 +1,51 @@
-import { AuthenticatedGuest, Season, Show, YourSeason } from "../types"
-import { FunctionComponent, useContext, useEffect, useState } from "react"
-import { Checkbox } from "./Checkbox"
-import { SetLoadingContext } from "../contexts"
-import { updateMySeason } from "../helpers/my_shows"
+import { AuthenticatedGuest, Season, Show, YourSeason } from "../types";
+import { FunctionComponent, useContext, useEffect, useState } from "react";
+import { Checkbox } from "./Checkbox";
+import { SetLoadingContext } from "../contexts";
+import { updateMySeason } from "../helpers/my_shows";
 
-type HasWatched = "unknown" | "partial" | boolean
+type HasWatched = "unknown" | "partial" | boolean;
 
 interface Props {
-  guest: AuthenticatedGuest
-  show: Show
-  season: Season
+  guest: AuthenticatedGuest;
+  show: Show;
+  season: Season;
 }
 
 export const SeenSeasonCheckbox: FunctionComponent<Props> = ({ guest, season, show }) => {
-  const [updating, setUpdating] = useState(false)
-  const [hasWatched, setHasWatched] = useState<HasWatched>("unknown")
-  const setLoading = useContext(SetLoadingContext)
+  const [updating, setUpdating] = useState(false);
+  const [hasWatched, setHasWatched] = useState<HasWatched>("unknown");
+  const setLoading = useContext(SetLoadingContext);
 
   useEffect(() => {
-    ;(async () => {
-      setLoading(true)
+    (async () => {
+      setLoading(true);
       const response = await fetch(`/api/shows/${show.slug}/seasons/${season.slug}.json`, {
         headers: { "X-SEASONING_TOKEN": guest.token },
-      })
-      setLoading(false)
+      });
+      setLoading(false);
 
       if (response.ok) {
-        const yourSeason: YourSeason = await response.json()
+        const yourSeason: YourSeason = await response.json();
 
-        const yourRelationship = yourSeason.your_relationship
+        const yourRelationship = yourSeason.your_relationship;
 
         if (yourRelationship) {
           if (yourRelationship.watched_episode_numbers.length === yourSeason.season.episode_count) {
-            setHasWatched(true)
+            setHasWatched(true);
           } else if (yourRelationship.watched_episode_numbers.length === 0) {
-            setHasWatched(false)
+            setHasWatched(false);
           } else {
-            setHasWatched("partial")
+            setHasWatched("partial");
           }
         } else {
-          setHasWatched(false)
+          setHasWatched(false);
         }
       } else {
-        throw new Error("Could not load season")
+        throw new Error("Could not load season");
       }
-    })()
-  }, [])
+    })();
+  }, []);
 
   return (
     <>
@@ -53,34 +53,34 @@ export const SeenSeasonCheckbox: FunctionComponent<Props> = ({ guest, season, sh
         className="text-yellow-500"
         inputRef={(input) => {
           if (input && hasWatched === "partial") {
-            input.indeterminate = true
+            input.indeterminate = true;
           } else if (input) {
-            input.indeterminate = false
+            input.indeterminate = false;
           }
         }}
         checked={hasWatched === true}
         disabled={hasWatched === "unknown" || updating}
         onChange={async () => {
-          const newHasWatched: boolean = hasWatched === true ? false : true
+          const newHasWatched: boolean = hasWatched === true ? false : true;
 
-          setLoading(true)
-          setUpdating(true)
+          setLoading(true);
+          setUpdating(true);
           const response = await updateMySeason(season, guest.token, {
             season: {
               watched: newHasWatched,
             },
-          })
+          });
 
-          setLoading(false)
-          setUpdating(false)
+          setLoading(false);
+          setUpdating(false);
 
           if (response.ok) {
-            setHasWatched(newHasWatched)
+            setHasWatched(newHasWatched);
           } else {
-            throw new Error("Could not toggle watched status")
+            throw new Error("Could not toggle watched status");
           }
         }}
       />
     </>
-  )
-}
+  );
+};

--- a/app/javascript/components/Select.tsx
+++ b/app/javascript/components/Select.tsx
@@ -1,8 +1,8 @@
 type Props = React.DetailedHTMLProps<
   React.SelectHTMLAttributes<HTMLSelectElement>,
   HTMLSelectElement
->
+>;
 
 export const Select = (props: Props) => {
-  return <select {...props} className="focus:border-yellow-400 focus:ring-yellow-400" />
-}
+  return <select {...props} className="focus:border-yellow-400 focus:ring-yellow-400" />;
+};

--- a/app/javascript/components/ShowMetadata.tsx
+++ b/app/javascript/components/ShowMetadata.tsx
@@ -1,4 +1,4 @@
-import { Show } from "../types"
+import { Show } from "../types";
 
 export const ShowMetadata = ({ show }: { show: Show }) => {
   return (
@@ -23,5 +23,5 @@ export const ShowMetadata = ({ show }: { show: Show }) => {
         )}
       </ul>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/components/ShowSearchBar.tsx
+++ b/app/javascript/components/ShowSearchBar.tsx
@@ -1,10 +1,10 @@
-import { AuthenticatedGuest, Show } from "../types"
-import { FunctionComponent, useContext, useEffect } from "react"
-import { Button } from "./Button"
-import debounce from "lodash.debounce"
-import { SetLoadingContext } from "../contexts"
-import { TextField } from "./TextField"
-import { useNavigate } from "react-router-dom"
+import { AuthenticatedGuest, Show } from "../types";
+import { FunctionComponent, useContext, useEffect } from "react";
+import { Button } from "./Button";
+import debounce from "lodash.debounce";
+import { SetLoadingContext } from "../contexts";
+import { TextField } from "./TextField";
+import { useNavigate } from "react-router-dom";
 
 const searchForShows = (
   title: string,
@@ -12,12 +12,12 @@ const searchForShows = (
   setLoading: (loadingState: boolean) => void,
   callback: (shows: Show[] | null) => void,
 ) => {
-  setLoading(true)
+  setLoading(true);
 
   if (!title) {
-    callback(null)
-    setLoading(false)
-    return
+    callback(null);
+    setLoading(false);
+    return;
   }
 
   fetch(`/api/shows.json?q=${encodeURIComponent(title)}`, {
@@ -26,39 +26,39 @@ const searchForShows = (
     },
   })
     .then((response) => {
-      setLoading(false)
+      setLoading(false);
       if (response.ok) {
-        return response.json()
+        return response.json();
       } else {
-        throw new Error("Could not search shows")
+        throw new Error("Could not search shows");
       }
     })
     .then((data) => {
-      callback(data.shows)
-    })
-}
-const debouncedSearch = debounce(searchForShows, 400, { trailing: true })
+      callback(data.shows);
+    });
+};
+const debouncedSearch = debounce(searchForShows, 400, { trailing: true });
 
 interface Props {
-  guest: AuthenticatedGuest
-  callback: (results: Show[] | null) => void
-  query: string
-  setQuery: (query: string) => void
+  guest: AuthenticatedGuest;
+  callback: (results: Show[] | null) => void;
+  query: string;
+  setQuery: (query: string) => void;
 }
 
 export const ShowSearchBar: FunctionComponent<Props> = ({ guest, callback, query, setQuery }) => {
-  const navigate = useNavigate()
-  const setLoading = useContext(SetLoadingContext)
+  const navigate = useNavigate();
+  const setLoading = useContext(SetLoadingContext);
   useEffect(() => {
-    debouncedSearch(query, guest.token, setLoading, callback)
-  }, [query])
+    debouncedSearch(query, guest.token, setLoading, callback);
+  }, [query]);
 
   return (
     <form
       className="md:mr-2 md:inline "
       onSubmit={(event) => {
-        event.preventDefault()
-        navigate(`/search?q=${encodeURIComponent(query)}`)
+        event.preventDefault();
+        navigate(`/search?q=${encodeURIComponent(query)}`);
       }}
     >
       <span className="mr-2">
@@ -70,5 +70,5 @@ export const ShowSearchBar: FunctionComponent<Props> = ({ guest, callback, query
       </span>
       <Button type="submit" value="Search" />
     </form>
-  )
-}
+  );
+};

--- a/app/javascript/components/StarRating.tsx
+++ b/app/javascript/components/StarRating.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent } from "react"
+import { FunctionComponent } from "react";
 
 interface Props {
-  rating: number
+  rating: number;
 }
 
 export const StarRating: FunctionComponent<Props> = ({ rating }) => {
@@ -18,13 +18,13 @@ export const StarRating: FunctionComponent<Props> = ({ rating }) => {
       <Star position={9} rating={rating} />
       <Star position={10} rating={rating} />
     </span>
-  )
-}
+  );
+};
 
 const Star = ({ position, rating }: { position: number; rating: number }) => {
   if (rating >= position) {
-    return <span className="text-yellow-400">★</span>
+    return <span className="text-yellow-400">★</span>;
   } else {
-    return <span>☆</span>
+    return <span>☆</span>;
   }
-}
+};

--- a/app/javascript/components/TextField.tsx
+++ b/app/javascript/components/TextField.tsx
@@ -1,5 +1,5 @@
-type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, "className" | "type">
+type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, "className" | "type">;
 
 export const TextField = (props: Props) => {
-  return <input type="text" {...props} className="focus:border-yellow-400 focus:ring-yellow-400" />
-}
+  return <input type="text" {...props} className="focus:border-yellow-400 focus:ring-yellow-400" />;
+};

--- a/app/javascript/components/Textarea.tsx
+++ b/app/javascript/components/Textarea.tsx
@@ -1,10 +1,10 @@
 type Props = Omit<
   React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement>,
   "className"
->
+>;
 
 export const Textarea = (props: Props) => {
   return (
     <textarea {...props} className="h-48 w-5/6 focus:border-yellow-400 focus:ring-yellow-400" />
-  )
-}
+  );
+};

--- a/app/javascript/components/YouTubeVideo.tsx
+++ b/app/javascript/components/YouTubeVideo.tsx
@@ -1,6 +1,6 @@
 type Props = {
-  id: string
-}
+  id: string;
+};
 
 export const YouTubeVideo = ({ id }: Props) => {
   return (
@@ -14,5 +14,5 @@ export const YouTubeVideo = ({ id }: Props) => {
         allowFullScreen
       ></iframe>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/components/YourShowsList.tsx
+++ b/app/javascript/components/YourShowsList.tsx
@@ -1,25 +1,25 @@
-import { FunctionComponent, useContext, useEffect, useState } from "react"
-import { Human, YourShow } from "../types"
-import { Link, useSearchParams } from "react-router-dom"
-import { Button } from "./Button"
-import { displayMyShowStatus } from "../helpers/my_shows"
-import { Markdown } from "./Markdown"
-import { Poster } from "./Poster"
-import queryString from "query-string"
-import { Select } from "./Select"
-import { SetLoadingContext } from "../contexts"
-import { TextField } from "./TextField"
+import { FunctionComponent, useContext, useEffect, useState } from "react";
+import { Human, YourShow } from "../types";
+import { Link, useSearchParams } from "react-router-dom";
+import { Button } from "./Button";
+import { displayMyShowStatus } from "../helpers/my_shows";
+import { Markdown } from "./Markdown";
+import { Poster } from "./Poster";
+import queryString from "query-string";
+import { Select } from "./Select";
+import { SetLoadingContext } from "../contexts";
+import { TextField } from "./TextField";
 
 interface YourShows {
-  your_shows: YourShow[]
+  your_shows: YourShow[];
 }
 interface Props {
-  human: Human
-  token: string
+  human: Human;
+  token: string;
 }
 
 interface ListShowProps {
-  shows: YourShow[]
+  shows: YourShow[];
 }
 const ListShows = ({ shows }: ListShowProps) => {
   if (shows.length) {
@@ -59,43 +59,43 @@ const ListShows = ({ shows }: ListShowProps) => {
                 <></>
               )}
             </div>
-          )
+          );
         })}
       </div>
-    )
+    );
   } else {
-    return <div>No shows yet. Maybe add some via the search at the top of the page?</div>
+    return <div>No shows yet. Maybe add some via the search at the top of the page?</div>;
   }
-}
+};
 
 export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
-  const globalSetLoading = useContext(SetLoadingContext)
-  const [loading, setLoading] = useState(true)
-  const [shows, setShows] = useState<YourShow[]>([])
-  const [searchParams, setSearchParams] = useSearchParams()
+  const globalSetLoading = useContext(SetLoadingContext);
+  const [loading, setLoading] = useState(true);
+  const [shows, setShows] = useState<YourShow[]>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const titleQueryValue = searchParams.get("title") || ""
+  const titleQueryValue = searchParams.get("title") || "";
   const statusesFilterValue = searchParams.getAll("statuses").length
     ? searchParams.getAll("statuses")
-    : ["currently_watching"]
+    : ["currently_watching"];
 
-  const page: number = parseInt(searchParams.get("page") || "") || 1
+  const page: number = parseInt(searchParams.get("page") || "") || 1;
 
   useEffect(() => {
-    globalSetLoading(true)
-    setLoading(true)
+    globalSetLoading(true);
+    setLoading(true);
 
-    const params: Record<string, unknown> = {}
+    const params: Record<string, unknown> = {};
 
     if (titleQueryValue) {
-      params.q = titleQueryValue
+      params.q = titleQueryValue;
     }
 
     if (statusesFilterValue.length) {
-      params.statuses = statusesFilterValue
+      params.statuses = statusesFilterValue;
     }
 
-    params.page = page
+    params.page = page;
 
     // TODO: debounce me
     fetch(`/api/your-shows.json?${queryString.stringify(params, { arrayFormat: "bracket" })}`, {
@@ -105,17 +105,17 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
     })
       .then((response) => {
         if (response.ok) {
-          return response.json()
+          return response.json();
         } else {
-          throw new Error("Could not fetch your shows")
+          throw new Error("Could not fetch your shows");
         }
       })
       .then((data: YourShows) => {
-        setShows(data.your_shows)
-        setLoading(false)
-        globalSetLoading(false)
-      })
-  }, [titleQueryValue, statusesFilterValue.join("-"), page])
+        setShows(data.your_shows);
+        setLoading(false);
+        globalSetLoading(false);
+      });
+  }, [titleQueryValue, statusesFilterValue.join("-"), page]);
 
   return (
     <div>
@@ -126,11 +126,11 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
             value={titleQueryValue}
             onChange={(event) => {
               if (event.target.value) {
-                searchParams.set("title", event.target.value)
+                searchParams.set("title", event.target.value);
               } else {
-                searchParams.delete("title")
+                searchParams.delete("title");
               }
-              setSearchParams(searchParams)
+              setSearchParams(searchParams);
             }}
           />
         </div>
@@ -138,12 +138,12 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
           multiple={true}
           value={statusesFilterValue}
           onChange={(event) => {
-            const statuses = Array.from(event.target.selectedOptions, (option) => option.value)
+            const statuses = Array.from(event.target.selectedOptions, (option) => option.value);
 
             setSearchParams({
               title: titleQueryValue,
               statuses: statuses,
-            })
+            });
           }}
         >
           <option value="might_watch">Might watch</option>
@@ -159,8 +159,8 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
             {page > 1 && (
               <Button
                 onClick={() => {
-                  searchParams.set("page", (page - 1).toString())
-                  setSearchParams(searchParams)
+                  searchParams.set("page", (page - 1).toString());
+                  setSearchParams(searchParams);
                 }}
               >
                 Previous
@@ -171,8 +171,8 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
           <div>
             <Button
               onClick={() => {
-                searchParams.set("page", (page + 1).toString())
-                setSearchParams(searchParams)
+                searchParams.set("page", (page + 1).toString());
+                setSearchParams(searchParams);
               }}
             >
               Next
@@ -181,5 +181,5 @@ export const YourShowsList: FunctionComponent<Props> = (props: Props) => {
         </div>
       </>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/contexts.ts
+++ b/app/javascript/contexts.ts
@@ -1,7 +1,7 @@
-import { createContext } from "react"
-import { Guest } from "./types"
+import { createContext } from "react";
+import { Guest } from "./types";
 
-export const GuestContext = createContext<Guest>({ authenticated: false })
+export const GuestContext = createContext<Guest>({ authenticated: false });
 export const SetLoadingContext = createContext((_: boolean) => {
   // no-op
-})
+});

--- a/app/javascript/entrypoints/application.ts
+++ b/app/javascript/entrypoints/application.ts
@@ -1,18 +1,18 @@
-import { AppWithRouter } from "../App"
-import { createElement } from "react"
-import { Guest } from "../types"
-import { render } from "react-dom"
-;(async () => {
-  const guestToken = localStorage.getItem("seasoning-guest-token")
-  let guest
+import { AppWithRouter } from "../App";
+import { createElement } from "react";
+import { Guest } from "../types";
+import { render } from "react-dom";
+(async () => {
+  const guestToken = localStorage.getItem("seasoning-guest-token");
+  let guest;
 
   if (guestToken) {
     const response = await fetch("/api/guest.json", {
       headers: { "X-SEASONING-TOKEN": guestToken },
-    })
-    guest = await response.json()
+    });
+    guest = await response.json();
   } else {
-    guest = { authenticated: false }
+    guest = { authenticated: false };
   }
 
   render(
@@ -24,5 +24,5 @@ import { render } from "react-dom"
       null,
     ),
     document.getElementById("app"),
-  )
-})()
+  );
+})();

--- a/app/javascript/helpers/my_shows.ts
+++ b/app/javascript/helpers/my_shows.ts
@@ -1,4 +1,4 @@
-import { Episode, HumanLimits, MyShowStatus, Season, Show } from "../types"
+import { Episode, HumanLimits, MyShowStatus, Season, Show } from "../types";
 
 export const displayMyShowStatus = (status: MyShowStatus): string => {
   return {
@@ -8,27 +8,27 @@ export const displayMyShowStatus = (status: MyShowStatus): string => {
     stopped_watching: "Stopped watching",
     waiting_for_more: "Waiting for more",
     finished: "Finished",
-  }[status]
-}
+  }[status];
+};
 
 export const displayMyShowStatusLimit = (status: MyShowStatus, limits: HumanLimits): string => {
   if (atLimit(status, limits)) {
-    return "(at limit!)"
+    return "(at limit!)";
   } else {
-    return ""
+    return "";
   }
-}
+};
 
 export const atLimit = (status: MyShowStatus, limits: HumanLimits): boolean => {
   if (status === "currently_watching") {
     return !!(
       limits.currently_watching_limit.max &&
       limits.currently_watching_limit.current >= limits.currently_watching_limit.max
-    )
+    );
   } else {
-    return false
+    return false;
   }
-}
+};
 
 export const updateMyShow = (
   show: Show,
@@ -42,8 +42,8 @@ export const updateMyShow = (
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
-  })
-}
+  });
+};
 
 export const updateMySeason = (
   season: Season,
@@ -57,8 +57,8 @@ export const updateMySeason = (
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
-  })
-}
+  });
+};
 
 export const updateMyEpisode = (
   season: Season,
@@ -73,5 +73,5 @@ export const updateMyEpisode = (
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
-  })
-}
+  });
+};

--- a/app/javascript/hooks.ts
+++ b/app/javascript/hooks.ts
@@ -1,23 +1,23 @@
-import { useEffect, useState } from "react"
+import { useEffect, useState } from "react";
 
-import { Guest } from "./types"
+import { Guest } from "./types";
 
-const DEFAULT_TITLE = "Seasoning"
+const DEFAULT_TITLE = "Seasoning";
 
 export const setHeadTitle = (title: string | undefined, deps?: React.DependencyList): void => {
   useEffect(() => {
-    document.title = title || DEFAULT_TITLE
+    document.title = title || DEFAULT_TITLE;
 
     return () => {
-      document.title = DEFAULT_TITLE
-    }
-  }, deps)
-}
+      document.title = DEFAULT_TITLE;
+    };
+  }, deps);
+};
 
 type LoadableData<T> =
   | { loading: true }
   | { loading: false; data: T }
-  | { loading: false; data: null }
+  | { loading: false; data: null };
 
 export const loadData = <T>(
   guest: Guest,
@@ -25,30 +25,30 @@ export const loadData = <T>(
   deps: React.DependencyList,
   setCurrentlyLoading: (_: boolean) => void,
 ): LoadableData<T> => {
-  const [data, setData] = useState<LoadableData<T>>({ loading: true })
+  const [data, setData] = useState<LoadableData<T>>({ loading: true });
 
   useEffect(() => {
-    ;(async () => {
-      const headers: Record<string, string> = {}
+    (async () => {
+      const headers: Record<string, string> = {};
       if (guest.authenticated) {
-        headers["X-SEASONING-TOKEN"] = guest.token
+        headers["X-SEASONING-TOKEN"] = guest.token;
       }
-      setCurrentlyLoading(true)
+      setCurrentlyLoading(true);
       const response = await fetch(url, {
         headers: headers,
-      })
-      setCurrentlyLoading(false)
+      });
+      setCurrentlyLoading(false);
 
       if (response.ok) {
-        const responseData: T = await response.json()
-        setData({ loading: false, data: responseData })
+        const responseData: T = await response.json();
+        setData({ loading: false, data: responseData });
       } else if (response.status === 404) {
-        setData({ loading: false, data: null })
+        setData({ loading: false, data: null });
       } else {
-        throw new Error(`Could not fetch data from ${url}`)
+        throw new Error(`Could not fetch data from ${url}`);
       }
-    })()
-  }, deps)
+    })();
+  }, deps);
 
-  return data
-}
+  return data;
+};

--- a/app/javascript/pages/AdminPage.tsx
+++ b/app/javascript/pages/AdminPage.tsx
@@ -1,33 +1,33 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Link, Navigate } from "react-router-dom"
-import { loadData, setHeadTitle } from "../hooks"
-import { Human } from "../types"
-import { useContext } from "react"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Link, Navigate } from "react-router-dom";
+import { loadData, setHeadTitle } from "../hooks";
+import { Human } from "../types";
+import { useContext } from "react";
 
 type AdminData = {
-  humansCount: number
-  showsCount: number
-  seasonsCount: number
-  reviewsCount: number
-  episodesCount: number
-  lastRefreshedTmdbConfigAt: string
-  recentHumans: Human[]
-}
+  humansCount: number;
+  showsCount: number;
+  seasonsCount: number;
+  reviewsCount: number;
+  episodesCount: number;
+  lastRefreshedTmdbConfigAt: string;
+  recentHumans: Human[];
+};
 
 export const AdminPage = () => {
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
 
-  setHeadTitle("Admin")
+  setHeadTitle("Admin");
 
-  const adminData = loadData<AdminData>(guest, `/api/admin.json`, [], setLoading)
+  const adminData = loadData<AdminData>(guest, `/api/admin.json`, [], setLoading);
 
   if (adminData.loading) {
-    return <p>Loading...</p>
+    return <p>Loading...</p>;
   }
 
   if (!adminData.data) {
-    return <Navigate to="/" />
+    return <Navigate to="/" />;
   }
 
   return (
@@ -67,10 +67,10 @@ export const AdminPage = () => {
               <li key={human.handle}>
                 <Link to={`/${human.handle}`}>{human.handle}</Link>
               </li>
-            )
+            );
           })}
         </ol>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/ChangelogPage.tsx
+++ b/app/javascript/pages/ChangelogPage.tsx
@@ -1,6 +1,6 @@
-import { FunctionComponent } from "react"
-import { Markdown } from "../components/Markdown"
-import { setHeadTitle } from "../hooks"
+import { FunctionComponent } from "react";
+import { Markdown } from "../components/Markdown";
+import { setHeadTitle } from "../hooks";
 
 const changelog = `
   As mentioned on [the credits page](/credits), this whole thing is open source, so feel free to check out [the repo](https://github.com/maxjacobson/seasoning) on GitHub.
@@ -66,10 +66,10 @@ const changelog = `
   1. **March 14, 2021** — People can add "note to self" about a show
   1. **March 13, 2021** — People can add shows they're interested in
   1. **March 9, 2021** — Development starts
-`
+`;
 
 export const ChangelogPage: FunctionComponent = () => {
-  setHeadTitle("Changelog")
+  setHeadTitle("Changelog");
 
   return (
     <div>
@@ -77,5 +77,5 @@ export const ChangelogPage: FunctionComponent = () => {
 
       <Markdown markdown={changelog} />
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/CreditsPage.tsx
+++ b/app/javascript/pages/CreditsPage.tsx
@@ -1,8 +1,8 @@
-import { FunctionComponent } from "react"
-import { setHeadTitle } from "../hooks"
+import { FunctionComponent } from "react";
+import { setHeadTitle } from "../hooks";
 
 export const CreditsPage: FunctionComponent = () => {
-  setHeadTitle("Credits")
+  setHeadTitle("Credits");
 
   return (
     <div>
@@ -41,5 +41,5 @@ export const CreditsPage: FunctionComponent = () => {
         </li>
       </ul>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/EpisodePage.tsx
+++ b/app/javascript/pages/EpisodePage.tsx
@@ -1,83 +1,83 @@
-import { Episode, Season, Show } from "../types"
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Link, useParams } from "react-router-dom"
-import { useContext, useEffect, useState } from "react"
-import { AirDate } from "../components/AirDate"
-import { MoreInfo } from "../components/MoreInfo"
-import { setHeadTitle } from "../hooks"
-import { ShowMetadata } from "../components/ShowMetadata"
+import { Episode, Season, Show } from "../types";
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Link, useParams } from "react-router-dom";
+import { useContext, useEffect, useState } from "react";
+import { AirDate } from "../components/AirDate";
+import { MoreInfo } from "../components/MoreInfo";
+import { setHeadTitle } from "../hooks";
+import { ShowMetadata } from "../components/ShowMetadata";
 
 interface LoadingEpisode {
-  loading: true
+  loading: true;
 }
 
 interface EpisodeFound {
-  loading: false
-  episode: Episode
-  show: Show
-  season: Season
+  loading: false;
+  episode: Episode;
+  show: Show;
+  season: Season;
 }
 
-type EpisodeData = LoadingEpisode | EpisodeFound
+type EpisodeData = LoadingEpisode | EpisodeFound;
 
 export const EpisodePage = () => {
-  const [response, setResponse] = useState<EpisodeData>({ loading: true })
-  const setLoading = useContext(SetLoadingContext)
-  const { showSlug, seasonSlug, episodeNumber } = useParams()
-  const guest = useContext(GuestContext)
+  const [response, setResponse] = useState<EpisodeData>({ loading: true });
+  const setLoading = useContext(SetLoadingContext);
+  const { showSlug, seasonSlug, episodeNumber } = useParams();
+  const guest = useContext(GuestContext);
 
   useEffect(() => {
     if (showSlug === undefined || seasonSlug === undefined || episodeNumber === undefined) {
-      return
+      return;
     }
 
-    ;(async () => {
-      let headers
+    (async () => {
+      let headers;
       if (guest.authenticated) {
-        headers = { "X-SEASONING_TOKEN": guest.token }
+        headers = { "X-SEASONING_TOKEN": guest.token };
       } else {
-        headers = {}
+        headers = {};
       }
-      setLoading(true)
+      setLoading(true);
       const response = await fetch(
         `/api/shows/${showSlug}/seasons/${seasonSlug}/episodes/${episodeNumber}.json`,
         {
           headers: headers,
         },
-      )
-      setLoading(false)
+      );
+      setLoading(false);
 
       if (response.ok) {
-        const { episode, show, season } = await response.json()
+        const { episode, show, season } = await response.json();
 
         setResponse({
           loading: false,
           episode: episode,
           show: show,
           season: season,
-        })
+        });
       } else {
-        throw new Error("Could not load episode")
+        throw new Error("Could not load episode");
       }
-    })()
-  }, [showSlug, seasonSlug, episodeNumber])
+    })();
+  }, [showSlug, seasonSlug, episodeNumber]);
 
   // TODO: this should be different
-  setHeadTitle("episode title", [])
+  setHeadTitle("episode title", []);
 
-  let headTitle
+  let headTitle;
 
   if (!response.loading) {
-    headTitle = `${response.show.title}  - ${response.episode.name}`
+    headTitle = `${response.show.title}  - ${response.episode.name}`;
   }
 
-  setHeadTitle(headTitle, [response])
+  setHeadTitle(headTitle, [response]);
 
   if (response.loading) {
-    return <p>Loading...</p>
+    return <p>Loading...</p>;
   }
 
-  const { show, episode, season } = response
+  const { show, episode, season } = response;
 
   return (
     <>
@@ -98,5 +98,5 @@ export const EpisodePage = () => {
 
       <ShowMetadata show={show} />
     </>
-  )
-}
+  );
+};

--- a/app/javascript/pages/HomePage.tsx
+++ b/app/javascript/pages/HomePage.tsx
@@ -1,20 +1,20 @@
-import { useContext, useEffect } from "react"
-import { GetStarted } from "../components/GetStarted"
-import { GuestContext } from "../contexts"
-import { useNavigate } from "react-router-dom"
+import { useContext, useEffect } from "react";
+import { GetStarted } from "../components/GetStarted";
+import { GuestContext } from "../contexts";
+import { useNavigate } from "react-router-dom";
 
 export const HomePage = () => {
-  const guest = useContext(GuestContext)
+  const guest = useContext(GuestContext);
 
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   useEffect(() => {
     if (guest.authenticated) {
-      navigate("/shows")
+      navigate("/shows");
     }
-  }, [])
+  }, []);
 
   if (guest.authenticated) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   } else {
     return (
       <div>
@@ -22,6 +22,6 @@ export const HomePage = () => {
         <h2 className="text-lg">This is seasoning, a website about TV shows</h2>
         <GetStarted />
       </div>
-    )
+    );
   }
-}
+};

--- a/app/javascript/pages/ImportShowPage.tsx
+++ b/app/javascript/pages/ImportShowPage.tsx
@@ -1,29 +1,29 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Import, Show } from "../types"
-import { useContext, useEffect, useState } from "react"
-import { useNavigate, useSearchParams } from "react-router-dom"
-import { Button } from "../components/Button"
-import queryString from "query-string"
-import { TextField } from "../components/TextField"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Import, Show } from "../types";
+import { useContext, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Button } from "../components/Button";
+import queryString from "query-string";
+import { TextField } from "../components/TextField";
 
 export const ImportShowPage = () => {
-  const [searchParams] = useSearchParams()
-  const searchQuery = searchParams.get("q")
-  const [showQuery, setShowQuery] = useState(searchQuery || "")
-  const [searching, setSearching] = useState(false)
-  const [importing, setImporting] = useState(false)
-  const [results, setResults] = useState<Import[] | null>(null)
-  const navigate = useNavigate()
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.get("q");
+  const [showQuery, setShowQuery] = useState(searchQuery || "");
+  const [searching, setSearching] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [results, setResults] = useState<Import[] | null>(null);
+  const navigate = useNavigate();
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
 
   const search = async () => {
     if (!guest.authenticated) {
-      return
+      return;
     }
 
-    setLoading(true)
-    setSearching(true)
+    setLoading(true);
+    setSearching(true);
 
     const response = await fetch(
       `/api/imports.json?${queryString.stringify({ query: showQuery })}`,
@@ -33,25 +33,25 @@ export const ImportShowPage = () => {
           "Content-Type": "application/json",
         },
       },
-    )
+    );
 
-    setLoading(false)
-    setSearching(false)
+    setLoading(false);
+    setSearching(false);
 
     if (response.ok) {
-      const data: { shows: Import[] } = await response.json()
-      setResults(data.shows)
+      const data: { shows: Import[] } = await response.json();
+      setResults(data.shows);
     } else {
-      throw new Error("failed to search")
+      throw new Error("failed to search");
     }
-  }
+  };
 
   useEffect(() => {
-    search()
-  }, [searchQuery])
+    search();
+  }, [searchQuery]);
 
   if (!guest.authenticated) {
-    return <div>Not found...</div>
+    return <div>Not found...</div>;
   }
 
   return (
@@ -66,9 +66,9 @@ export const ImportShowPage = () => {
 
       <form
         onSubmit={async (event) => {
-          event.preventDefault()
+          event.preventDefault();
 
-          await search()
+          await search();
         }}
       >
         <div>
@@ -102,8 +102,8 @@ export const ImportShowPage = () => {
                 <Button
                   disabled={importing}
                   onClick={async () => {
-                    setLoading(true)
-                    setImporting(true)
+                    setLoading(true);
+                    setImporting(true);
 
                     const response = await fetch(`/api/imports.json`, {
                       headers: {
@@ -116,16 +116,16 @@ export const ImportShowPage = () => {
                           id: result.id,
                         },
                       }),
-                    })
+                    });
 
-                    setLoading(false)
-                    setImporting(false)
+                    setLoading(false);
+                    setImporting(false);
 
                     if (response.ok) {
-                      const data: { show: Show } = await response.json()
-                      navigate(`/shows/${data.show.slug}`)
+                      const data: { show: Show } = await response.json();
+                      navigate(`/shows/${data.show.slug}`);
                     } else {
-                      throw new Error("could not import show")
+                      throw new Error("could not import show");
                     }
                   }}
                 >
@@ -137,5 +137,5 @@ export const ImportShowPage = () => {
         </div>
       )}
     </>
-  )
-}
+  );
+};

--- a/app/javascript/pages/NewSeasonReviewPage.tsx
+++ b/app/javascript/pages/NewSeasonReviewPage.tsx
@@ -1,46 +1,46 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { HumanSettings, Rating, SeasonReview, Visibility, YourSeason } from "../types"
-import { loadData, setHeadTitle } from "../hooks"
-import { useContext, useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router-dom"
-import { Button } from "../components/Button"
-import { Select } from "../components/Select"
-import { Textarea } from "../components/Textarea"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { HumanSettings, Rating, SeasonReview, Visibility, YourSeason } from "../types";
+import { loadData, setHeadTitle } from "../hooks";
+import { useContext, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "../components/Button";
+import { Select } from "../components/Select";
+import { Textarea } from "../components/Textarea";
 
 export const NewSeasonReviewPage = () => {
-  const [body, setBody] = useState("")
-  const [visibility, setVisibility] = useState<Visibility | undefined>(undefined)
-  const [rating, setRating] = useState<Rating | undefined>(undefined)
-  const [validationError, setValidationError] = useState<null | Record<string, string[]>>(null)
-  const { showSlug, seasonSlug } = useParams()
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
+  const [body, setBody] = useState("");
+  const [visibility, setVisibility] = useState<Visibility | undefined>(undefined);
+  const [rating, setRating] = useState<Rating | undefined>(undefined);
+  const [validationError, setValidationError] = useState<null | Record<string, string[]>>(null);
+  const { showSlug, seasonSlug } = useParams();
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
 
-  const settings = loadData<HumanSettings>(guest, "/api/settings.json", [], setLoading)
+  const settings = loadData<HumanSettings>(guest, "/api/settings.json", [], setLoading);
 
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!settings.loading) {
-      setVisibility(settings.data?.default_review_visibility)
+      setVisibility(settings.data?.default_review_visibility);
     }
-  }, [settings])
+  }, [settings]);
 
   const yourSeason = loadData<YourSeason>(
     guest,
     `/api/shows/${showSlug}/seasons/${seasonSlug}.json`,
     [showSlug, seasonSlug],
     setLoading,
-  )
+  );
 
-  setHeadTitle("New review")
+  setHeadTitle("New review");
 
   if (settings.loading || yourSeason.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (!settings.data || !yourSeason.data || !guest.authenticated) {
-    return <div>Not found</div>
+    return <div>Not found</div>;
   }
 
   return (
@@ -78,7 +78,7 @@ export const NewSeasonReviewPage = () => {
         <Button
           disabled={!visibility}
           onClick={async () => {
-            setLoading(true)
+            setLoading(true);
             const response = await fetch("/api/season-reviews.json", {
               method: "POST",
               headers: {
@@ -94,21 +94,21 @@ export const NewSeasonReviewPage = () => {
                 show_id: yourSeason.data.show.id,
                 season_id: yourSeason.data.season.id,
               }),
-            })
-            setLoading(false)
+            });
+            setLoading(false);
 
             if (response.ok) {
-              const data = await response.json()
-              const review: SeasonReview = data.review
+              const data = await response.json();
+              const review: SeasonReview = data.review;
               const url = `/${guest.human.handle}/shows/${showSlug}/${seasonSlug}${
                 review.viewing === 1 ? "" : `/${review.viewing}`
-              }`
-              navigate(url)
+              }`;
+              navigate(url);
             } else if (response.status === 400) {
-              const data = await response.json()
-              setValidationError(data)
+              const data = await response.json();
+              setValidationError(data);
             } else {
-              throw new Error("Could not create review")
+              throw new Error("Could not create review");
             }
           }}
         >
@@ -125,26 +125,26 @@ export const NewSeasonReviewPage = () => {
                   <div key={i}>
                     {key} {errorMessage}
                   </div>
-                )
+                );
               })}
             </>
-          )
+          );
         })}
     </div>
-  )
-}
+  );
+};
 
 const RatingPicker = ({
   rating,
   setRating,
 }: {
-  rating: Rating | undefined
-  setRating: (_: Rating | undefined) => void
+  rating: Rating | undefined;
+  setRating: (_: Rating | undefined) => void;
 }) => {
   const choiceProps = {
     choice: rating,
     setChoice: setRating,
-  }
+  };
 
   return (
     <>
@@ -165,33 +165,33 @@ const RatingPicker = ({
       </div>
       <div>{rating ? `Rating: ${rating}` : "No rating"}</div>
     </>
-  )
-}
+  );
+};
 
 const RatingChoice = ({
   position,
   setChoice,
   choice,
 }: {
-  position: Rating
-  setChoice: (_: Rating | undefined) => void
-  choice: Rating | undefined
+  position: Rating;
+  setChoice: (_: Rating | undefined) => void;
+  choice: Rating | undefined;
 }) => {
   const starProps = {
     onClick: () => setChoice(position),
-  }
+  };
 
   if (choice && choice >= position) {
     return (
       <span {...starProps} className="cursor-pointer text-yellow-400">
         ★
       </span>
-    )
+    );
   } else {
     return (
       <span {...starProps} className="cursor-pointer">
         ☆
       </span>
-    )
+    );
   }
-}
+};

--- a/app/javascript/pages/NotFoundPage.tsx
+++ b/app/javascript/pages/NotFoundPage.tsx
@@ -1,3 +1,3 @@
-import { FunctionComponent } from "react"
+import { FunctionComponent } from "react";
 
-export const NotFoundPage: FunctionComponent = () => <p>Not sure what that page is, sorry</p>
+export const NotFoundPage: FunctionComponent = () => <p>Not sure what that page is, sorry</p>;

--- a/app/javascript/pages/ProfileFollowersPage.tsx
+++ b/app/javascript/pages/ProfileFollowersPage.tsx
@@ -1,28 +1,28 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Link, useParams } from "react-router-dom"
-import { loadData, setHeadTitle } from "../hooks"
-import { Human } from "../types"
-import { useContext } from "react"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Link, useParams } from "react-router-dom";
+import { loadData, setHeadTitle } from "../hooks";
+import { Human } from "../types";
+import { useContext } from "react";
 
 export const ProfileFollowersPage = () => {
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
-  const { handle } = useParams()
-  setHeadTitle(`${handle}'s followers`)
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
+  const { handle } = useParams();
+  setHeadTitle(`${handle}'s followers`);
 
   const followersData = loadData<{ humans: Human[] }>(
     guest,
     `/api/profiles/${handle}/followers.json`,
     [],
     setLoading,
-  )
+  );
 
   if (followersData.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (!followersData.data) {
-    return <div>Not found</div>
+    return <div>Not found</div>;
   }
 
   if (followersData.data.humans.length === 0) {
@@ -33,7 +33,7 @@ export const ProfileFollowersPage = () => {
           <p>None yet!</p>
         </div>
       </>
-    )
+    );
   }
 
   return (
@@ -45,9 +45,9 @@ export const ProfileFollowersPage = () => {
             <li key={human.handle}>
               <Link to={`/${human.handle}`}>{human.handle}</Link>
             </li>
-          )
+          );
         })}
       </ol>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/ProfileFollowingPage.tsx
+++ b/app/javascript/pages/ProfileFollowingPage.tsx
@@ -1,28 +1,28 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Link, useParams } from "react-router-dom"
-import { loadData, setHeadTitle } from "../hooks"
-import { Human } from "../types"
-import { useContext } from "react"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Link, useParams } from "react-router-dom";
+import { loadData, setHeadTitle } from "../hooks";
+import { Human } from "../types";
+import { useContext } from "react";
 
 export const ProfileFollowingPage = () => {
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
-  const { handle } = useParams()
-  setHeadTitle(`${handle}'s follows`)
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
+  const { handle } = useParams();
+  setHeadTitle(`${handle}'s follows`);
 
   const followingData = loadData<{ humans: Human[] }>(
     guest,
     `/api/profiles/${handle}/following.json`,
     [],
     setLoading,
-  )
+  );
 
   if (followingData.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (!followingData.data) {
-    return <div>Not found</div>
+    return <div>Not found</div>;
   }
 
   if (followingData.data.humans.length === 0) {
@@ -33,7 +33,7 @@ export const ProfileFollowingPage = () => {
           <p>None yet!</p>
         </div>
       </>
-    )
+    );
   }
 
   return (
@@ -45,9 +45,9 @@ export const ProfileFollowingPage = () => {
             <li key={human.handle}>
               <Link to={`/${human.handle}`}>{human.handle}</Link>
             </li>
-          )
+          );
         })}
       </ol>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/ProfilePage.tsx
+++ b/app/javascript/pages/ProfilePage.tsx
@@ -1,81 +1,81 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Link, useParams } from "react-router-dom"
-import { useContext, useEffect, useState } from "react"
-import { Button } from "../components/Button"
-import { Poster } from "../components/Poster"
-import { Profile } from "../types"
-import { setHeadTitle } from "../hooks"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Link, useParams } from "react-router-dom";
+import { useContext, useEffect, useState } from "react";
+import { Button } from "../components/Button";
+import { Poster } from "../components/Poster";
+import { Profile } from "../types";
+import { setHeadTitle } from "../hooks";
 
 interface StillLoading {
-  loading: true
+  loading: true;
 }
 
 interface ProfileNotFound {
-  loading: false
-  profile: null
+  loading: false;
+  profile: null;
 }
 
 interface LoadedProfileData {
-  loading: false
-  profile: Profile
+  loading: false;
+  profile: Profile;
 }
 
-type ProfileData = StillLoading | LoadedProfileData | ProfileNotFound
+type ProfileData = StillLoading | LoadedProfileData | ProfileNotFound;
 
 export const ProfilePage = () => {
-  const [profileData, setProfile] = useState<ProfileData>({ loading: true })
-  const { handle } = useParams()
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
+  const [profileData, setProfile] = useState<ProfileData>({ loading: true });
+  const { handle } = useParams();
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
 
-  setHeadTitle(handle)
+  setHeadTitle(handle);
 
   useEffect(() => {
-    const headers: Record<string, string> = {}
+    const headers: Record<string, string> = {};
     if (guest.authenticated) {
-      headers["X-SEASONING-TOKEN"] = guest.token
+      headers["X-SEASONING-TOKEN"] = guest.token;
     }
-    setLoading(true)
+    setLoading(true);
     fetch(`/api/profiles/${handle}.json`, { headers: headers })
       .then((response) => {
-        setLoading(false)
+        setLoading(false);
         if (response.ok) {
-          return response.json()
+          return response.json();
         } else if (response.status === 404) {
-          throw new Error("Not found")
+          throw new Error("Not found");
         } else {
-          throw new Error("Could not fetch profile")
+          throw new Error("Could not fetch profile");
         }
       })
       .then((data: { profile: Profile }) => {
         setProfile({
           loading: false,
           profile: data.profile,
-        })
+        });
       })
       .catch((err) => {
         if (err.message === "Not found") {
           setProfile({
             loading: false,
             profile: null,
-          })
+          });
         } else {
-          throw err
+          throw err;
         }
-      })
-  }, [handle])
+      });
+  }, [handle]);
 
   if (profileData.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   } else if (!profileData.profile) {
     return (
       <div>
         <h1 className="text-xl">Not found</h1>
         <p>No one goes by that name around these parts</p>
       </div>
-    )
+    );
   } else {
-    const { profile } = profileData
+    const { profile } = profileData;
 
     return (
       <div>
@@ -94,15 +94,15 @@ export const ProfilePage = () => {
                 body: JSON.stringify({
                   followee: handle,
                 }),
-              })
+              });
 
               if (!response.ok) {
-                throw new Error("Could not follow")
+                throw new Error("Could not follow");
               }
 
-              const data = await response.json()
+              const data = await response.json();
 
-              setProfile({ loading: false, profile: data.profile })
+              setProfile({ loading: false, profile: data.profile });
             }}
           >
             {profile.your_relationship.you_follow_them ? "Following" : "Follow"}
@@ -143,7 +143,7 @@ export const ProfilePage = () => {
                             {show.title}
                           </Link>
                         </div>
-                      )
+                      );
                     })}
                   </div>
                 ) : (
@@ -154,6 +154,6 @@ export const ProfilePage = () => {
           </>
         </div>
       </div>
-    )
+    );
   }
-}
+};

--- a/app/javascript/pages/ProfileReviewsPage.tsx
+++ b/app/javascript/pages/ProfileReviewsPage.tsx
@@ -1,29 +1,29 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { loadData, setHeadTitle } from "../hooks"
-import { SeasonReview, Show } from "../types"
-import { SeasonReviewSummary } from "../components/SeasonReviewSummary"
-import { useContext } from "react"
-import { useParams } from "react-router-dom"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { loadData, setHeadTitle } from "../hooks";
+import { SeasonReview, Show } from "../types";
+import { SeasonReviewSummary } from "../components/SeasonReviewSummary";
+import { useContext } from "react";
+import { useParams } from "react-router-dom";
 
 export const ProfileReviewsPage = () => {
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
-  const { handle } = useParams()
-  setHeadTitle(`${handle}'s reviews`)
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
+  const { handle } = useParams();
+  setHeadTitle(`${handle}'s reviews`);
 
   const reviewsData = loadData<{ reviews: { review: SeasonReview; show: Show }[] }>(
     guest,
     `/api/profiles/${handle}/season-reviews.json`,
     [],
     setLoading,
-  )
+  );
 
   if (reviewsData.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (!reviewsData.data) {
-    return <div>Not found</div>
+    return <div>Not found</div>;
   }
 
   if (reviewsData.data.reviews.length === 0) {
@@ -34,18 +34,18 @@ export const ProfileReviewsPage = () => {
           <p>No reviews yet!</p>
         </div>
       </>
-    )
+    );
   }
 
   return (
     <div>
       <h1 className="text-2xl">{handle}&rsquo;s reviews</h1>
       {reviewsData.data.reviews.map(({ review, show }) => {
-        return <SeasonReviewSummary review={review} show={show} key={review.id} />
+        return <SeasonReviewSummary review={review} show={show} key={review.id} />;
       })}
       <p>
         <strong>Note:</strong> this is just the 10 most recent reviews!
       </p>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/RedeemMagicLinkPage.tsx
+++ b/app/javascript/pages/RedeemMagicLinkPage.tsx
@@ -1,86 +1,86 @@
-import { FunctionComponent, useContext, useEffect, useState } from "react"
-import { Link, useNavigate, useParams } from "react-router-dom"
-import { Button } from "../components/Button"
-import { Guest } from "../types"
-import { SetLoadingContext } from "../contexts"
-import { TextField } from "../components/TextField"
+import { FunctionComponent, useContext, useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { Button } from "../components/Button";
+import { Guest } from "../types";
+import { SetLoadingContext } from "../contexts";
+import { TextField } from "../components/TextField";
 
 interface Props {
-  setGuest: (guest: Guest) => void
+  setGuest: (guest: Guest) => void;
 }
 
 interface AlreadyExists {
-  already_exists: true
-  email: string
-  handle: string
-  session_token: string
-  admin: boolean
+  already_exists: true;
+  email: string;
+  handle: string;
+  session_token: string;
+  admin: boolean;
 }
 
 interface NewHuman {
-  already_exists: false
-  email: string
+  already_exists: false;
+  email: string;
 }
 
-type Redemption = AlreadyExists | NewHuman
+type Redemption = AlreadyExists | NewHuman;
 
 interface LoadingMagicLink {
-  loading: true
+  loading: true;
 }
 interface ValidMagicLink {
-  loading: false
-  email: string
+  loading: false;
+  email: string;
 }
 interface MagicLinkNotFound {
-  loading: false
-  email: null
+  loading: false;
+  email: null;
 }
 
-type MagicLinkInfo = LoadingMagicLink | ValidMagicLink | MagicLinkNotFound
+type MagicLinkInfo = LoadingMagicLink | ValidMagicLink | MagicLinkNotFound;
 
 export const RedeemMagicLinkPage: FunctionComponent<Props> = ({ setGuest }: Props) => {
-  const [magicLinkInfo, setMagicLinkInfo] = useState<MagicLinkInfo>({ loading: true })
-  const [handle, setHandle] = useState<string>("")
-  const [creating, setCreating] = useState(false)
-  const navigate = useNavigate()
-  const { token } = useParams()
-  const setLoading = useContext(SetLoadingContext)
+  const [magicLinkInfo, setMagicLinkInfo] = useState<MagicLinkInfo>({ loading: true });
+  const [handle, setHandle] = useState<string>("");
+  const [creating, setCreating] = useState(false);
+  const navigate = useNavigate();
+  const { token } = useParams();
+  const setLoading = useContext(SetLoadingContext);
 
   useEffect(() => {
-    setLoading(true)
-    ;(async () => {
+    setLoading(true);
+    (async () => {
       const response = await fetch(`/api/magic-links/${token}.json`, {
         headers: {
           "Content-Type": "application/json",
         },
-      })
+      });
 
-      setLoading(false)
+      setLoading(false);
 
       if (response.status === 404) {
-        setMagicLinkInfo({ loading: false, email: null })
+        setMagicLinkInfo({ loading: false, email: null });
       } else if (!response.ok) {
-        throw new Error("Could not redeem magic link")
+        throw new Error("Could not redeem magic link");
       } else {
-        const data: Redemption = await response.json()
+        const data: Redemption = await response.json();
 
         if (data.already_exists) {
-          localStorage.setItem("seasoning-guest-token", data.session_token)
+          localStorage.setItem("seasoning-guest-token", data.session_token);
           setGuest({
             authenticated: true,
             human: { handle: data.handle, admin: data.admin },
             token: data.session_token,
-          })
-          navigate("/")
+          });
+          navigate("/");
         } else {
-          setMagicLinkInfo({ loading: false, email: data.email })
+          setMagicLinkInfo({ loading: false, email: data.email });
         }
       }
-    })()
-  }, [])
+    })();
+  }, []);
 
   if (magicLinkInfo.loading) {
-    return <div>Checking your magic link....</div>
+    return <div>Checking your magic link....</div>;
   }
 
   if (magicLinkInfo.email) {
@@ -92,11 +92,11 @@ export const RedeemMagicLinkPage: FunctionComponent<Props> = ({ setGuest }: Prop
 
           <form
             onSubmit={(e) => {
-              e.preventDefault()
+              e.preventDefault();
 
-              setLoading(true)
+              setLoading(true);
 
-              setCreating(true)
+              setCreating(true);
 
               fetch("/api/humans.json", {
                 body: JSON.stringify({
@@ -111,15 +111,15 @@ export const RedeemMagicLinkPage: FunctionComponent<Props> = ({ setGuest }: Prop
                 },
               })
                 .then((response) => {
-                  setLoading(false)
+                  setLoading(false);
                   if (response.ok) {
-                    return response.json()
+                    return response.json();
                   } else {
-                    throw new Error("Could not create human")
+                    throw new Error("Could not create human");
                   }
                 })
                 .then((data: AlreadyExists) => {
-                  localStorage.setItem("seasoning-guest-token", data.session_token)
+                  localStorage.setItem("seasoning-guest-token", data.session_token);
                   setGuest({
                     authenticated: true,
                     human: {
@@ -127,9 +127,9 @@ export const RedeemMagicLinkPage: FunctionComponent<Props> = ({ setGuest }: Prop
                       admin: data.admin,
                     },
                     token: data.session_token,
-                  })
-                  navigate("/")
-                })
+                  });
+                  navigate("/");
+                });
             }}
           >
             <span className="mr-2">
@@ -143,7 +143,7 @@ export const RedeemMagicLinkPage: FunctionComponent<Props> = ({ setGuest }: Prop
           </form>
         </div>
       </div>
-    )
+    );
   } else {
     return (
       <div>
@@ -153,6 +153,6 @@ export const RedeemMagicLinkPage: FunctionComponent<Props> = ({ setGuest }: Prop
           <Link to="/">Try again?</Link>
         </p>
       </div>
-    )
+    );
   }
-}
+};

--- a/app/javascript/pages/ReviewsFeedPage.tsx
+++ b/app/javascript/pages/ReviewsFeedPage.tsx
@@ -1,61 +1,61 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { SeasonReview, Show } from "../types"
-import { useContext, useEffect, useState } from "react"
-import { Navigate } from "react-router-dom"
-import { SeasonReviewSummary } from "../components/SeasonReviewSummary"
-import { setHeadTitle } from "../hooks"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { SeasonReview, Show } from "../types";
+import { useContext, useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { SeasonReviewSummary } from "../components/SeasonReviewSummary";
+import { setHeadTitle } from "../hooks";
 
 interface LoadingReviewsFeedData {
-  loading: true
+  loading: true;
 }
 
 interface LoadedReviewsFeedData {
-  loading: false
+  loading: false;
   data: {
-    show: Show
-    review: SeasonReview
-  }[]
+    show: Show;
+    review: SeasonReview;
+  }[];
 }
 
-type ReviewsFeedData = LoadingReviewsFeedData | LoadedReviewsFeedData
+type ReviewsFeedData = LoadingReviewsFeedData | LoadedReviewsFeedData;
 
 export const ReviewsFeedPage = () => {
-  const [feedData, setFeedData] = useState<ReviewsFeedData>({ loading: true })
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
+  const [feedData, setFeedData] = useState<ReviewsFeedData>({ loading: true });
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
 
   useEffect(() => {
-    ;(async () => {
+    (async () => {
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
-      }
+      };
       if (guest.authenticated) {
-        headers["X-SEASONING-TOKEN"] = guest.token
+        headers["X-SEASONING-TOKEN"] = guest.token;
       }
 
-      setLoading(true)
+      setLoading(true);
       const response = await fetch("/api/season-reviews.json", {
         headers: headers,
-      })
-      setLoading(false)
+      });
+      setLoading(false);
 
       if (response.ok) {
-        const data = await response.json()
-        setFeedData({ loading: false, data: data.data })
+        const data = await response.json();
+        setFeedData({ loading: false, data: data.data });
       } else {
-        throw new Error("Could not load reviews")
+        throw new Error("Could not load reviews");
       }
-    })()
-  }, [])
+    })();
+  }, []);
 
-  setHeadTitle("Reviews", [feedData])
+  setHeadTitle("Reviews", [feedData]);
 
   if (!guest.authenticated) {
-    return <Navigate to="/" />
+    return <Navigate to="/" />;
   }
 
   if (feedData.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   return (
@@ -63,8 +63,8 @@ export const ReviewsFeedPage = () => {
       <h1 className="text-xl">Reviews</h1>
       <h2 className="text-lg">Recent 10 reviews</h2>
       {feedData.data.map(({ review, show }) => {
-        return <SeasonReviewSummary key={review.id} review={review} show={show} />
+        return <SeasonReviewSummary key={review.id} review={review} show={show} />;
       })}
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/RoadmapPage.tsx
+++ b/app/javascript/pages/RoadmapPage.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent } from "react"
-import { Markdown } from "../components/Markdown"
+import { FunctionComponent } from "react";
+import { Markdown } from "../components/Markdown";
 
-import { setHeadTitle } from "../hooks"
+import { setHeadTitle } from "../hooks";
 
 const roadmap = `
   Some things I'm planning to work on:
@@ -25,10 +25,10 @@ const roadmap = `
   1. Some kind of notification when new episodes are available to watch
   1. Some way to mark seasons as "skipped" -- for example if you add the bachelor because you want to watch the latest episode of the bachelor but you don't want to watch all 27 seasons, just the new one
   1. Some way to mark episodes as "skipped" -- for example if you start watching saturday night live mid-season and don't feel compelled to go back and watch the old episodes
-`
+`;
 
 export const RoadmapPage: FunctionComponent = () => {
-  setHeadTitle("Roadmap")
+  setHeadTitle("Roadmap");
 
   return (
     <div>
@@ -36,5 +36,5 @@ export const RoadmapPage: FunctionComponent = () => {
 
       <Markdown markdown={roadmap} />
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/SearchResultsPage.tsx
+++ b/app/javascript/pages/SearchResultsPage.tsx
@@ -1,27 +1,27 @@
-import { Link, useSearchParams } from "react-router-dom"
-import { FunctionComponent } from "react"
-import { setHeadTitle } from "../hooks"
-import { Show } from "../types"
+import { Link, useSearchParams } from "react-router-dom";
+import { FunctionComponent } from "react";
+import { setHeadTitle } from "../hooks";
+import { Show } from "../types";
 interface Props {
-  searchResults: Show[] | null
+  searchResults: Show[] | null;
 }
 
 const Year = ({ date: str }: { date: string }) => {
-  const date = new Date(str)
+  const date = new Date(str);
 
-  return <>({date.getFullYear()})</>
-}
+  return <>({date.getFullYear()})</>;
+};
 
 export const SearchResultsPage: FunctionComponent<Props> = ({ searchResults }) => {
-  setHeadTitle("Search results")
+  setHeadTitle("Search results");
 
-  const [searchParams] = useSearchParams()
-  const searchQuery = searchParams.get("q")
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.get("q");
 
-  const importParams = new URLSearchParams()
+  const importParams = new URLSearchParams();
 
   if (searchQuery) {
-    importParams.set("q", searchQuery)
+    importParams.set("q", searchQuery);
   }
 
   return (
@@ -49,5 +49,5 @@ export const SearchResultsPage: FunctionComponent<Props> = ({ searchResults }) =
         .
       </p>
     </>
-  )
-}
+  );
+};

--- a/app/javascript/pages/SeasonPage.tsx
+++ b/app/javascript/pages/SeasonPage.tsx
@@ -1,78 +1,78 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Link, useParams } from "react-router-dom"
-import { useContext, useEffect, useState } from "react"
-import { AirDate } from "../components/AirDate"
-import { MoreInfo } from "../components/MoreInfo"
-import { Poster } from "../components/Poster"
-import { SeenEpisodeCheckbox } from "../components/SeenEpisodeCheckbox"
-import { setHeadTitle } from "../hooks"
-import { ShowMetadata } from "../components/ShowMetadata"
-import { YourSeason } from "../types"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Link, useParams } from "react-router-dom";
+import { useContext, useEffect, useState } from "react";
+import { AirDate } from "../components/AirDate";
+import { MoreInfo } from "../components/MoreInfo";
+import { Poster } from "../components/Poster";
+import { SeenEpisodeCheckbox } from "../components/SeenEpisodeCheckbox";
+import { setHeadTitle } from "../hooks";
+import { ShowMetadata } from "../components/ShowMetadata";
+import { YourSeason } from "../types";
 
 interface LoadingSeason {
-  loading: true
+  loading: true;
 }
 
 interface SeasonNotFound {
-  loading: false
-  yourSeason: null
+  loading: false;
+  yourSeason: null;
 }
 
 interface SeasonFound {
-  loading: false
-  yourSeason: YourSeason
+  loading: false;
+  yourSeason: YourSeason;
 }
 
-type SeasonData = LoadingSeason | SeasonNotFound | SeasonFound
+type SeasonData = LoadingSeason | SeasonNotFound | SeasonFound;
 
 export const SeasonPage = () => {
-  const [response, setResponse] = useState<SeasonData>({ loading: true })
-  const setLoading = useContext(SetLoadingContext)
-  const { showSlug, seasonSlug } = useParams()
-  const guest = useContext(GuestContext)
+  const [response, setResponse] = useState<SeasonData>({ loading: true });
+  const setLoading = useContext(SetLoadingContext);
+  const { showSlug, seasonSlug } = useParams();
+  const guest = useContext(GuestContext);
 
   useEffect(() => {
     if (!seasonSlug) {
-      return
+      return;
     }
 
-    ;(async () => {
-      let headers
+    (async () => {
+      let headers;
       if (guest.authenticated) {
-        headers = { "X-SEASONING_TOKEN": guest.token }
+        headers = { "X-SEASONING_TOKEN": guest.token };
       } else {
-        headers = {}
+        headers = {};
       }
-      setLoading(true)
+      setLoading(true);
       const response = await fetch(`/api/shows/${showSlug}/seasons/${seasonSlug}.json`, {
         headers: headers,
-      })
-      setLoading(false)
+      });
+      setLoading(false);
 
       if (response.status === 404) {
-        setResponse({ loading: false, yourSeason: null })
+        setResponse({ loading: false, yourSeason: null });
       } else if (response.ok) {
-        const yourSeason: YourSeason = await response.json()
-        setResponse({ loading: false, yourSeason: yourSeason })
+        const yourSeason: YourSeason = await response.json();
+        setResponse({ loading: false, yourSeason: yourSeason });
       } else {
-        throw new Error("Could not load season")
+        throw new Error("Could not load season");
       }
-    })()
-  }, [showSlug, seasonSlug])
+    })();
+  }, [showSlug, seasonSlug]);
 
-  let headTitle
+  let headTitle;
 
   if (!response.loading && response.yourSeason) {
-    headTitle = `${response.yourSeason.show.title} - ${response.yourSeason.season.name}`
+    headTitle = `${response.yourSeason.show.title} - ${response.yourSeason.season.name}`;
   }
 
-  setHeadTitle(headTitle, [response])
+  setHeadTitle(headTitle, [response]);
 
   if (response.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
-  const { yourSeason } = response
+  const { yourSeason } = response;
 
   if (!yourSeason) {
     return (
@@ -83,7 +83,7 @@ export const SeasonPage = () => {
           <Link to={`/shows/${showSlug}`}>Back</Link>
         </p>
       </div>
-    )
+    );
   }
 
   return (
@@ -138,7 +138,7 @@ export const SeasonPage = () => {
                         </td>
                       )}
                     </tr>
-                  )
+                  );
                 })}
               </tbody>
             </table>
@@ -168,7 +168,7 @@ export const SeasonPage = () => {
                         {new Date(review.created_at).toLocaleDateString()}
                       </Link>
                     </li>
-                  )
+                  );
                 })}
               </ul>
             ) : (
@@ -180,5 +180,5 @@ export const SeasonPage = () => {
 
       <ShowMetadata show={yourSeason.show} />
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/SeasonReviewPage.tsx
+++ b/app/javascript/pages/SeasonReviewPage.tsx
@@ -1,54 +1,54 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Human, Season, SeasonReview, Show } from "../types"
-import { Link, useNavigate, useParams } from "react-router-dom"
-import { useContext, useEffect, useState } from "react"
-import { Button } from "../components/Button"
-import { Markdown } from "../components/Markdown"
-import { Poster } from "../components/Poster"
-import queryString from "query-string"
-import { setHeadTitle } from "../hooks"
-import { StarRating } from "../components/StarRating"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Human, Season, SeasonReview, Show } from "../types";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useContext, useEffect, useState } from "react";
+import { Button } from "../components/Button";
+import { Markdown } from "../components/Markdown";
+import { Poster } from "../components/Poster";
+import queryString from "query-string";
+import { setHeadTitle } from "../hooks";
+import { StarRating } from "../components/StarRating";
 
 interface LoadingReviewData {
-  loading: true
+  loading: true;
 }
 
 interface LoadedReviewData {
-  loading: false
-  review: SeasonReview
-  show: Show
-  season: Season
-  author: Human
+  loading: false;
+  review: SeasonReview;
+  show: Show;
+  season: Season;
+  author: Human;
 }
 
 interface ReviewDataNotFound {
-  loading: false
-  review: null
-  season: null
-  show: null
+  loading: false;
+  review: null;
+  season: null;
+  show: null;
 }
-type SeasonReviewData = LoadingReviewData | LoadedReviewData | ReviewDataNotFound
+type SeasonReviewData = LoadingReviewData | LoadedReviewData | ReviewDataNotFound;
 
 export const SeasonReviewPage = () => {
-  const [reviewData, setReviewData] = useState<SeasonReviewData>({ loading: true })
-  const { handle, showSlug, seasonSlug, viewing } = useParams()
-  const navigate = useNavigate()
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
+  const [reviewData, setReviewData] = useState<SeasonReviewData>({ loading: true });
+  const { handle, showSlug, seasonSlug, viewing } = useParams();
+  const navigate = useNavigate();
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
 
   useEffect(() => {
-    ;(async () => {
+    (async () => {
       if (!handle || !showSlug || !seasonSlug) {
-        setReviewData({ loading: false, review: null, season: null, show: null })
-        return
+        setReviewData({ loading: false, review: null, season: null, show: null });
+        return;
       }
 
-      setLoading(true)
+      setLoading(true);
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
-      }
+      };
       if (guest.authenticated) {
-        headers["X-SEASONING-TOKEN"] = guest.token
+        headers["X-SEASONING-TOKEN"] = guest.token;
       }
       const response = await fetch(
         `/api/season-review.json?${queryString.stringify({
@@ -60,35 +60,35 @@ export const SeasonReviewPage = () => {
         {
           headers: headers,
         },
-      )
-      setLoading(false)
+      );
+      setLoading(false);
 
       if (response.ok) {
         const data: { review: SeasonReview; show: Show; season: Season; author: Human } =
-          await response.json()
+          await response.json();
         setReviewData({
           loading: false,
           review: data.review,
           show: data.show,
           season: data.season,
           author: data.author,
-        })
+        });
       } else if (response.status === 404) {
-        setReviewData({ loading: false, review: null, season: null, show: null })
+        setReviewData({ loading: false, review: null, season: null, show: null });
       } else {
-        throw new Error("Could not load review")
+        throw new Error("Could not load review");
       }
-    })()
-  }, [handle, showSlug, seasonSlug, viewing])
+    })();
+  }, [handle, showSlug, seasonSlug, viewing]);
 
-  let headTitle
+  let headTitle;
   if (!reviewData.loading && reviewData.review) {
-    headTitle = `${reviewData.show.title} - ${reviewData.season.name} Review`
+    headTitle = `${reviewData.show.title} - ${reviewData.season.name} Review`;
   }
-  setHeadTitle(headTitle, [reviewData])
+  setHeadTitle(headTitle, [reviewData]);
 
   if (reviewData.loading) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
 
   if (!reviewData.review) {
@@ -100,10 +100,10 @@ export const SeasonReviewPage = () => {
           <Link to={`/${handle}`}>Back</Link>
         </p>
       </div>
-    )
+    );
   }
 
-  const { review, show, season } = reviewData
+  const { review, show, season } = reviewData;
 
   return (
     <div>
@@ -141,14 +141,14 @@ export const SeasonReviewPage = () => {
           <div>
             <Button
               onClick={async (event) => {
-                event.preventDefault()
+                event.preventDefault();
 
                 if (confirm("Are you sure?")) {
                   const headers: Record<string, string> = {
                     "Content-Type": "application/json",
-                  }
+                  };
                   if (guest.authenticated) {
-                    headers["X-SEASONING-TOKEN"] = guest.token
+                    headers["X-SEASONING-TOKEN"] = guest.token;
                   }
                   const response = await fetch(
                     `/api/season-review.json?${queryString.stringify({
@@ -161,13 +161,13 @@ export const SeasonReviewPage = () => {
                       headers: headers,
                       method: "DELETE",
                     },
-                  )
-                  setLoading(false)
+                  );
+                  setLoading(false);
 
                   if (response.ok) {
-                    navigate(`/${handle}`)
+                    navigate(`/${handle}`);
                   } else {
-                    throw new Error("Could not delete")
+                    throw new Error("Could not delete");
                   }
                 }
               }}
@@ -178,5 +178,5 @@ export const SeasonReviewPage = () => {
         )}
       </div>
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/pages/SettingsPage.tsx
+++ b/app/javascript/pages/SettingsPage.tsx
@@ -1,34 +1,34 @@
-import { AuthenticatedGuest, HumanSettings } from "../types"
-import { FunctionComponent, useContext, useEffect, useState } from "react"
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { Checkbox } from "../components/Checkbox"
-import { Select } from "../components/Select"
-import { setHeadTitle } from "../hooks"
+import { AuthenticatedGuest, HumanSettings } from "../types";
+import { FunctionComponent, useContext, useEffect, useState } from "react";
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { Checkbox } from "../components/Checkbox";
+import { Select } from "../components/Select";
+import { setHeadTitle } from "../hooks";
 
 interface LoadingSettingsData {
-  loading: true
+  loading: true;
 }
 
 interface LoadedSettingsData {
-  loading: false
-  settings: HumanSettings
+  loading: false;
+  settings: HumanSettings;
 }
 
-type SettingsData = LoadingSettingsData | LoadedSettingsData
+type SettingsData = LoadingSettingsData | LoadedSettingsData;
 
 export const SettingsPage = () => {
-  setHeadTitle("Settings")
+  setHeadTitle("Settings");
 
   return (
     <div>
       <h1 className="text-2xl">Settings</h1>
       <SettingsBody />
     </div>
-  )
-}
+  );
+};
 
 const SettingsBody = () => {
-  const guest = useContext(GuestContext)
+  const guest = useContext(GuestContext);
 
   return (
     <div>
@@ -40,54 +40,54 @@ const SettingsBody = () => {
         </div>
       )}
     </div>
-  )
-}
+  );
+};
 
 interface EditSettingsProps {
-  guest: AuthenticatedGuest
+  guest: AuthenticatedGuest;
 }
 
 const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSettingsProps) => {
-  const [currentlyUpdating, setCurrentlyUpdating] = useState(false)
-  const [settingsData, setSettingsData] = useState<SettingsData>({ loading: true })
-  const setLoading = useContext(SetLoadingContext)
+  const [currentlyUpdating, setCurrentlyUpdating] = useState(false);
+  const [settingsData, setSettingsData] = useState<SettingsData>({ loading: true });
+  const setLoading = useContext(SetLoadingContext);
 
   useEffect(() => {
-    ;(async () => {
-      setLoading(true)
+    (async () => {
+      setLoading(true);
       const response = await fetch("/api/settings.json", {
         headers: {
           "X-SEASONING-TOKEN": guest.token,
         },
-      })
-      setLoading(false)
+      });
+      setLoading(false);
 
       if (response.ok) {
-        const data: HumanSettings = await response.json()
-        setSettingsData({ loading: false, settings: data })
+        const data: HumanSettings = await response.json();
+        setSettingsData({ loading: false, settings: data });
       } else {
-        throw new Error("Could not load settings")
+        throw new Error("Could not load settings");
       }
-    })()
-  }, [])
+    })();
+  }, []);
 
   const update = async (patch: Record<string, unknown>) => {
-    setCurrentlyUpdating(true)
-    setLoading(true)
-    const response = await updateMySettings(guest.token, patch)
-    setCurrentlyUpdating(false)
-    setLoading(false)
+    setCurrentlyUpdating(true);
+    setLoading(true);
+    const response = await updateMySettings(guest.token, patch);
+    setCurrentlyUpdating(false);
+    setLoading(false);
 
     if (response.ok) {
-      const data: HumanSettings = await response.json()
-      setSettingsData({ loading: false, settings: data })
+      const data: HumanSettings = await response.json();
+      setSettingsData({ loading: false, settings: data });
     } else {
-      throw new Error("Could not update settings")
+      throw new Error("Could not update settings");
     }
-  }
+  };
 
   if (settingsData.loading) {
-    return <div>Loading settings...</div>
+    return <div>Loading settings...</div>;
   }
 
   return (
@@ -118,7 +118,7 @@ const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSetti
         <Select
           value={settingsData.settings.default_review_visibility}
           onChange={(event) => {
-            update({ default_review_visibility: event.target.value })
+            update({ default_review_visibility: event.target.value });
           }}
           disabled={currentlyUpdating}
         >
@@ -142,11 +142,11 @@ const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSetti
         <Select
           value={settingsData.settings.currently_watching_limit || -1}
           onChange={(event) => {
-            const value = event.target.value
+            const value = event.target.value;
             if (parseInt(value) > 0) {
-              update({ currently_watching_limit: value })
+              update({ currently_watching_limit: value });
             } else {
-              update({ currently_watching_limit: null })
+              update({ currently_watching_limit: null });
             }
           }}
           disabled={currentlyUpdating}
@@ -165,8 +165,8 @@ const EditSettings: FunctionComponent<EditSettingsProps> = ({ guest }: EditSetti
         </Select>
       </div>
     </>
-  )
-}
+  );
+};
 
 const updateMySettings = (token: string, body: Record<string, unknown>): Promise<Response> => {
   return fetch("/api/settings.json", {
@@ -176,5 +176,5 @@ const updateMySettings = (token: string, body: Record<string, unknown>): Promise
       "X-SEASONING-TOKEN": token,
       "Content-Type": "application/json",
     },
-  })
-}
+  });
+};

--- a/app/javascript/pages/ShowPage.tsx
+++ b/app/javascript/pages/ShowPage.tsx
@@ -1,75 +1,75 @@
-import { GuestContext, SetLoadingContext } from "../contexts"
-import { useContext, useEffect, useState } from "react"
-import { AddShowButton } from "../components/AddShowButton"
-import { ChooseShowStatusButton } from "../components/ChooseShowStatusButton"
-import { MoreInfo } from "../components/MoreInfo"
-import { NoteToSelf } from "../components/NoteToSelf"
-import { Poster } from "../components/Poster"
-import { RemoveShowButton } from "../components/RemoveShowButton"
-import { SeasonsList } from "../components/SeasonsList"
-import { setHeadTitle } from "../hooks"
-import { ShowMetadata } from "../components/ShowMetadata"
-import { useParams } from "react-router-dom"
-import { YourShow } from "../types"
+import { GuestContext, SetLoadingContext } from "../contexts";
+import { useContext, useEffect, useState } from "react";
+import { AddShowButton } from "../components/AddShowButton";
+import { ChooseShowStatusButton } from "../components/ChooseShowStatusButton";
+import { MoreInfo } from "../components/MoreInfo";
+import { NoteToSelf } from "../components/NoteToSelf";
+import { Poster } from "../components/Poster";
+import { RemoveShowButton } from "../components/RemoveShowButton";
+import { SeasonsList } from "../components/SeasonsList";
+import { setHeadTitle } from "../hooks";
+import { ShowMetadata } from "../components/ShowMetadata";
+import { useParams } from "react-router-dom";
+import { YourShow } from "../types";
 
 type LoadingShowData = {
-  loading: true
-  data: null
-}
+  loading: true;
+  data: null;
+};
 
 type LoadedShowData = {
-  loading: false
-  data: YourShow
-}
+  loading: false;
+  data: YourShow;
+};
 
-type ShowData = LoadingShowData | LoadedShowData
+type ShowData = LoadingShowData | LoadedShowData;
 
 export const ShowPage = () => {
-  const guest = useContext(GuestContext)
-  const setLoading = useContext(SetLoadingContext)
-  const { showSlug } = useParams()
+  const guest = useContext(GuestContext);
+  const setLoading = useContext(SetLoadingContext);
+  const { showSlug } = useParams();
   const [showData, setShowData] = useState<ShowData>({
     loading: true,
     data: null,
-  })
+  });
   useEffect(() => {
     if (!showSlug) {
-      return
+      return;
     }
 
-    setLoading(true)
-    ;(async () => {
-      let headers
+    setLoading(true);
+    (async () => {
+      let headers;
       if (guest.authenticated) {
-        headers = { "X-SEASONING_TOKEN": guest.token }
+        headers = { "X-SEASONING_TOKEN": guest.token };
       } else {
-        headers = {}
+        headers = {};
       }
       const response = await fetch(`/api/shows/${showSlug}.json`, {
         headers: headers,
-      })
+      });
 
-      setLoading(false)
+      setLoading(false);
 
       if (response.ok) {
-        const data: YourShow = await response.json()
-        setShowData({ loading: false, data: data })
+        const data: YourShow = await response.json();
+        setShowData({ loading: false, data: data });
       } else {
-        throw new Error("Could not load show")
+        throw new Error("Could not load show");
       }
-    })()
-  }, [showSlug])
+    })();
+  }, [showSlug]);
 
-  setHeadTitle(showData.loading ? undefined : showData.data.show.title, [showData])
+  setHeadTitle(showData.loading ? undefined : showData.data.show.title, [showData]);
 
   if (showData.loading) {
     return (
       <div>
         <h1>Loading show...</h1>
       </div>
-    )
+    );
   } else {
-    const { data } = showData
+    const { data } = showData;
 
     return (
       <div>
@@ -86,7 +86,7 @@ export const ShowPage = () => {
                     show={data.show}
                     token={guest.token}
                     onRemove={() => {
-                      setShowData({ loading: false, data: { show: data.show } })
+                      setShowData({ loading: false, data: { show: data.show } });
                     }}
                   />
                 ) : (
@@ -94,7 +94,7 @@ export const ShowPage = () => {
                     token={guest.token}
                     show={data.show}
                     setYourShow={(yourShow) => {
-                      setShowData({ loading: false, data: yourShow })
+                      setShowData({ loading: false, data: yourShow });
                     }}
                   />
                 )}
@@ -108,7 +108,7 @@ export const ShowPage = () => {
                 show={data.show}
                 yourRelationship={data.your_relationship}
                 setYourShow={(yourShow) => {
-                  setShowData({ loading: false, data: yourShow })
+                  setShowData({ loading: false, data: yourShow });
                 }}
               />
             )}
@@ -120,7 +120,7 @@ export const ShowPage = () => {
                 token={guest.token}
                 yourShow={data}
                 updateYourShow={(newData) => {
-                  setShowData({ loading: false, data: newData })
+                  setShowData({ loading: false, data: newData });
                 }}
               />
             </div>
@@ -146,6 +146,6 @@ export const ShowPage = () => {
 
         <ShowMetadata show={data.show} />
       </div>
-    )
+    );
   }
-}
+};

--- a/app/javascript/pages/YourShowsPage.tsx
+++ b/app/javascript/pages/YourShowsPage.tsx
@@ -1,10 +1,10 @@
-import { GuestContext } from "../contexts"
-import { Link } from "react-router-dom"
-import { useContext } from "react"
-import { YourShowsList } from "../components/YourShowsList"
+import { GuestContext } from "../contexts";
+import { Link } from "react-router-dom";
+import { useContext } from "react";
+import { YourShowsList } from "../components/YourShowsList";
 
 export const YourShowsPage = () => {
-  const guest = useContext(GuestContext)
+  const guest = useContext(GuestContext);
 
   return (
     <div>
@@ -17,5 +17,5 @@ export const YourShowsPage = () => {
         </div>
       )}
     </div>
-  )
-}
+  );
+};

--- a/app/javascript/types.ts
+++ b/app/javascript/types.ts
@@ -1,63 +1,63 @@
 export interface HumanSettings {
-  share_currently_watching: boolean
-  default_review_visibility: Visibility
-  currently_watching_limit: number | null
+  share_currently_watching: boolean;
+  default_review_visibility: Visibility;
+  currently_watching_limit: number | null;
 }
 
 export interface Human {
-  handle: string
-  admin: boolean
+  handle: string;
+  admin: boolean;
 }
 
 interface Limit {
-  current: number
-  max: number | null
+  current: number;
+  max: number | null;
 }
 
 export interface HumanLimits {
-  currently_watching_limit: Limit
+  currently_watching_limit: Limit;
 }
 
 export interface AuthenticatedGuest {
-  authenticated: true
-  human: Human
-  token: string
+  authenticated: true;
+  human: Human;
+  token: string;
 }
 
 export interface AnonymousGuest {
-  authenticated: false
+  authenticated: false;
 }
 
-export type Guest = AuthenticatedGuest | AnonymousGuest
+export type Guest = AuthenticatedGuest | AnonymousGuest;
 
 export interface Season {
-  id: number
-  name: string
-  season_number: number
-  episode_count: number
-  slug: string
-  poster_url: string | null
-  episodes: Episode[]
+  id: number;
+  name: string;
+  season_number: number;
+  episode_count: number;
+  slug: string;
+  poster_url: string | null;
+  episodes: Episode[];
 }
 
 export interface Episode {
-  name: string
-  episode_number: number
-  still_url: string | null
-  air_date: string | null
-  available: boolean
+  name: string;
+  episode_number: number;
+  still_url: string | null;
+  air_date: string | null;
+  available: boolean;
 }
 
 export interface Show {
-  id: number
-  title: string
-  slug: string
-  poster_url: string | null
-  seasons: Season[]
-  tmdb_tv_id: string
-  first_air_date: string | null
-  tmdb_last_refreshed_at: string | null
-  tmdb_next_refresh_at: string | null
+  id: number;
+  title: string;
+  slug: string;
+  poster_url: string | null;
+  seasons: Season[];
+  tmdb_tv_id: string;
+  first_air_date: string | null;
+  tmdb_last_refreshed_at: string | null;
+  tmdb_next_refresh_at: string | null;
 }
 
 export type MyShowStatus =
@@ -66,65 +66,65 @@ export type MyShowStatus =
   | "currently_watching"
   | "stopped_watching"
   | "waiting_for_more"
-  | "finished"
+  | "finished";
 
-export type Visibility = "anybody" | "mutuals" | "myself"
+export type Visibility = "anybody" | "mutuals" | "myself";
 
 export interface YourRelationshipToShow {
-  added_at: string
-  note_to_self: string | undefined
-  status: MyShowStatus
+  added_at: string;
+  note_to_self: string | undefined;
+  status: MyShowStatus;
 }
 
 export interface YourShow {
-  show: Show
-  your_relationship?: YourRelationshipToShow
+  show: Show;
+  your_relationship?: YourRelationshipToShow;
 }
 
 interface YourRelationshipToProfile {
-  self: boolean
-  you_follow_them: boolean
-  they_follow_you: boolean
+  self: boolean;
+  you_follow_them: boolean;
+  they_follow_you: boolean;
 }
 
 export interface Profile {
-  handle: string
-  created_at: string
-  currently_watching?: Show[]
-  your_relationship?: YourRelationshipToProfile
-  reviews_count: number
-  followers_count: number
-  following_count: number
+  handle: string;
+  created_at: string;
+  currently_watching?: Show[];
+  your_relationship?: YourRelationshipToProfile;
+  reviews_count: number;
+  followers_count: number;
+  following_count: number;
 }
 
-export type Rating = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
+export type Rating = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 export interface SeasonReview {
-  body: string
-  visibility: boolean
-  created_at: string
-  updated_at: string
-  rating: Rating | undefined
-  author: Human
-  season: Season
-  viewing: number
-  id: number
+  body: string;
+  visibility: boolean;
+  created_at: string;
+  updated_at: string;
+  rating: Rating | undefined;
+  author: Human;
+  season: Season;
+  viewing: number;
+  id: number;
 }
 
 export interface YourRelationshipToSeason {
-  watched: boolean
-  watched_episode_numbers: number[]
+  watched: boolean;
+  watched_episode_numbers: number[];
 }
 
 export interface YourSeason {
-  show: Show
-  season: Season
-  your_relationship?: YourRelationshipToSeason
-  your_reviews?: SeasonReview[]
+  show: Show;
+  season: Season;
+  your_relationship?: YourRelationshipToSeason;
+  your_reviews?: SeasonReview[];
 }
 
 export interface Import {
-  id: number
-  name: string
-  poster_url: string | null
-  year: number | null
+  id: number;
+  name: string;
+  poster_url: string | null;
+  year: number | null;
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,4 +3,4 @@ module.exports = {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-default-export */
-import { Config } from "tailwindcss"
-import forms from "@tailwindcss/forms"
+import { Config } from "tailwindcss";
+import forms from "@tailwindcss/forms";
 
 const config: Config = {
   content: ["./app/**/*.{ts,tsx}"],
@@ -9,6 +9,6 @@ const config: Config = {
     extend: {},
   },
   plugins: [forms],
-}
+};
 
-export default config
+export default config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "vite"
-import RubyPlugin from "vite-plugin-ruby"
-import react from "@vitejs/plugin-react"
+import { defineConfig } from "vite";
+import RubyPlugin from "vite-plugin-ruby";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react(), RubyPlugin()],
-})
+});


### PR DESCRIPTION
For a few reasons:

1. this is the default config, so might as well run with the default
2. I think it'll make it easier to upgrade eslint. In #1175, ESLint is failing because it's seeing some of the odd leading semicolons and complaining about those. Using trailing semicolons everywhere means we don't need to use leading semicolons anywhere. Being normal pays off.