### PR TITLE
Remove dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,26 +22,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1000
-    groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@typescript-eslint/*"
-      prettier:
-        patterns:
-          - "prettier"
-          - "prettier-*"
-      vite:
-        patterns:
-          - "vite"
-          - "@vitejs/*"
-          - "vite-*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-      tailwind:
-        patterns:
-          - "tailwindcss"
-          - "@tailwindcss/*"


### PR DESCRIPTION
They seem to sort of clash with my mergeabot config in an interesting way. It seems like if you have a big enough group, one of the dependencies in the group gets updated before the five day window has passed, and so the PR gets updated, and so the PR doesn't get merged, and nothing ever gets merged. By removing the groups I'm hoping that more PRs will actually get merged because each dependency isn't updated that often. I probably didn't explain that very well because I just woke up. Let's see though.