### PR TITLE
Use the shopify ruby lsp vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,7 @@
     "dbaeumer.vscode-eslint",
     "eamodio.gitlens",
     "esbenp.prettier-vscode",
-    "rebornix.ruby",
     "kaiwood.endwise",
-    "rubocop.vscode-rubocop"
+    "shopify.ruby-lsp"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-  "ruby.lint": {
-    "rubocop": false
-  },
   "editor.formatOnSave": true,
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,


### PR DESCRIPTION
This seems to replace both the (deprecated) ruby one and the rubocop one. Nice.