### PR TITLE
Make CI a little more resilient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
       - run: npm install
       - run: exe/ruby-lint
       - run: exe/node-lint
-      - run: rake assets:precompile
+      - run: bundle exec rake assets:precompile


### PR DESCRIPTION
I'm seeing this error on some dependabot PRs:

```
Gem::LoadError: You have already activated rake 13.0.6, but your Gemfile requires rake 13.1.0. Prepending `bundle exec` to your command may solve this.
```