### PR TITLE
Address active support deprecation warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,9 @@ module Seasoning
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
+    config.active_support.cache_format_version = 6.1
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
This one:

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
```

Per the instructions I need to first deploy this, and then after that I can follow up by configuring it to use 7.0 and then the warning goes away and it should be seamless.