### PR TITLE
Address active support deprecation warning (pt 2)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Seasoning
     config.load_defaults 6.1
 
     # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
-    config.active_support.cache_format_version = 6.1
+    config.active_support.cache_format_version = 7.0
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
This one:

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
```