### PR TITLE
Fix off-by-one error in air date availability

### DIFF
--- a/app/javascript/components/AirDate.tsx
+++ b/app/javascript/components/AirDate.tsx
@@ -1,14 +1,38 @@
 import { FunctionComponent } from "react";
 
+const isAvailable = (dateStr: string): boolean => {
+  const inputDate = new Date(
+    parseInt(dateStr.split("-")[0]), // year
+    parseInt(dateStr.split("-")[1]) - 1, // month (0-indexed in JavaScript)
+    parseInt(dateStr.split("-")[2]), // day
+  );
+  const today = new Date();
+
+  const inputDateWithoutTime = new Date(
+    inputDate.getFullYear(),
+    inputDate.getMonth(),
+    inputDate.getDate(),
+  );
+  const todayWithoutTime = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  return inputDateWithoutTime <= todayWithoutTime;
+};
+
 interface Props {
   date: string | null;
-  available: boolean;
 }
 
-export const AirDate: FunctionComponent<Props> = ({ date: dateStr, available }: Props) => {
+export const AirDate: FunctionComponent<Props> = ({ date: dateStr }: Props) => {
   if (dateStr) {
-    const date: Date = new Date(dateStr);
-    const dateFormatted = date.toLocaleDateString(undefined, { timeZone: "UTC" });
+    const inputDate = new Date(dateStr + "T00:00:00");
+
+    const dateFormatted = new Intl.DateTimeFormat("en-US", {
+      month: "2-digit",
+      day: "2-digit",
+      year: "numeric",
+    }).format(inputDate);
+
+    const available = isAvailable(dateStr);
 
     if (available) {
       return <span>{dateFormatted}</span>;

--- a/app/javascript/pages/EpisodePage.tsx
+++ b/app/javascript/pages/EpisodePage.tsx
@@ -97,7 +97,7 @@ export const EpisodePage = () => {
       <div>{episode.still_url && <img src={episode.still_url} />}</div>
 
       <div>
-        Air date: <AirDate date={episode.air_date} available={episode.available} />
+        Air date: <AirDate date={episode.air_date} />
       </div>
 
       <ShowMetadata show={show} />

--- a/app/javascript/pages/SeasonPage.tsx
+++ b/app/javascript/pages/SeasonPage.tsx
@@ -125,7 +125,7 @@ export const SeasonPage = () => {
                         </Link>
                       </td>
                       <td>
-                        <AirDate date={episode.air_date} available={episode.available} />
+                        <AirDate date={episode.air_date} />
                       </td>
                       {guest.authenticated && yourSeason.your_relationship && (
                         <td>

--- a/app/javascript/types.ts
+++ b/app/javascript/types.ts
@@ -45,7 +45,6 @@ export interface Episode {
   episode_number: number;
   still_url: string | null;
   air_date: string | null;
-  available: boolean;
 }
 
 export interface Show {

--- a/app/serializers/episode_serializer.rb
+++ b/app/serializers/episode_serializer.rb
@@ -1,11 +1,7 @@
 # Serializes the episode to JSON
 class EpisodeSerializer < Oj::Serializer
   attributes :name, :episode_number, :air_date
-  serializer_attributes :still_url, :available
-
-  def available
-    episode.available?
-  end
+  serializer_attributes :still_url
 
   def still_url
     episode.still.url


### PR DESCRIPTION
When an episode airs tomorrow, sometimes the UI will indicate that it's already available, just because it's already tomorrow in UTC. We can fix this by checking the availability client-side.

Claude.ai helped me write this and it was so frustrating and painful and annoying and I don't even really like this code but to be fair it seems to have been helpful.