### PR TITLE
Lower test parallelization threshold

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,6 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = { host: "127.0.0.1:57081" }
+
+  config.active_support.test_parallelization_threshold = 10
 end


### PR DESCRIPTION
The default is 50 but I don't even have that many tests yet and I just want to try it out.