### PR TITLE
Whoops, bring back settings api endpoint

### DIFF
--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -1,0 +1,10 @@
+module API
+  # The current human can look up and manipulate their settings
+  class SettingsController < ApplicationController
+    def show
+      authorize! { current_human.present? }
+
+      render json: SettingsSerializer.one(current_human)
+    end
+  end
+end

--- a/app/javascript/pages/NewSeasonReviewPage.tsx
+++ b/app/javascript/pages/NewSeasonReviewPage.tsx
@@ -16,7 +16,6 @@ export const NewSeasonReviewPage = () => {
   const guest = useContext(GuestContext);
   const setLoading = useContext(SetLoadingContext);
 
-  // FIXME: I actually broke this whoops!
   const settings = loadData<HumanSettings>(guest, "/api/settings.json", [], setLoading);
 
   const navigate = useNavigate();

--- a/app/serializers/settings_serializer.rb
+++ b/app/serializers/settings_serializer.rb
@@ -1,0 +1,8 @@
+# Serializes someone's settings
+class SettingsSerializer < Oj::Serializer
+  attributes(
+    :currently_watching_limit,
+    :default_review_visibility,
+    :share_currently_watching
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
           resources :episodes, only: [:show]
         end
       end
+      resource :settings, only: [:show]
       resources :season_reviews, only: [:create], path: "/season-reviews"
       resource :season_review, only: [:show, :destroy], path: "/season-review"
       resource :human_limits, only: [:show], path: "/human-limits", controller: "human_limits"


### PR DESCRIPTION
The new season review page still depends on this