### PR TITLE
Update season name over time

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -3,7 +3,7 @@
 class Season < ApplicationRecord
   belongs_to :show
   has_many :episodes, dependent: :destroy
-  before_create -> { self.slug = name&.gsub(/[^a-z0-9\s]/i, "")&.parameterize }
+  before_save -> { self.slug = name&.gsub(/[^a-z0-9\s]/i, "")&.parameterize }
 
   def poster
     Poster.new(tmdb_poster_path.presence || show.tmdb_poster_path)

--- a/app/services/refresh_show.rb
+++ b/app/services/refresh_show.rb
@@ -17,6 +17,7 @@ RefreshShow = lambda { |show|
       season = show.seasons.find_by(season_number: tmdb_season.season_number)
       if season.present?
         season.update!(
+          name: tmdb_season.name,
           episode_count: tmdb_season.episode_count,
           tmdb_id: tmdb_season.id,
           tmdb_poster_path: tmdb_season.poster_path


### PR DESCRIPTION
Noticed that the current top chef season name changed from "Canada" to "Destination Canda" and that did not sync over to Seasoning. Let's sync that over. It does mean that links will change over time but I think that's fine, whatever, people will figure it out.