### PR TITLE
Improve new hooks scripts

### DIFF
--- a/bin/maybe-bundle-install
+++ b/bin/maybe-bundle-install
@@ -2,13 +2,13 @@
 
 set -e
 
-path="tmp/digests/Gemfile.lock.txt"
-mkdir -p tmp/digests/
+path="tmp/digests-Gemfile.lock.txt"
 
 if test -f $path; then
-  if md5 --quiet --check="$(cat $path)" Gemfile.lock > "$path"; then
+  if md5sum --quiet --strict --check "$path"; then
     exit 0
   fi
 fi
 
-bundle install
+bundle install --quiet
+md5sum Gemfile.lock > "$path"

--- a/bin/maybe-npm-install
+++ b/bin/maybe-npm-install
@@ -2,14 +2,14 @@
 
 set -e
 
-path="tmp/digests/package-lock.json.txt"
-mkdir -p tmp/digests/
+path="tmp/digests-package-lock.json.txt"
 
 if test -f $path; then
-  if md5 --quiet --check="$(cat $path)" package-lock.json > "$path"; then
+  if md5sum --quiet --strict --check "$path"; then
     exit 0
   fi
 fi
 
-npm install
-npm run playwright:install
+npm install --silent
+npm run --silent playwright:install
+md5sum package-lock.json > "$path"


### PR DESCRIPTION
I tried these on a different computer and realized that they don't ever create the digest file as-written...

I also noticed that this other computer (my fedora linux laptop) has `md5sum` but not `md5` so I refactored to prefer using md5sum. My Mac had both. Hopefully it's the same md5sum and it works just as well when I go back to the Mac and try it there...