### PR TITLE
Improve capybara configuration

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,15 +6,12 @@ Capybara.register_driver :my_playwright do |app|
                                    headless: (false unless ENV["CI"] || ENV["HEADLESS"]))
 end
 
+Capybara.server = :puma, { Silent: true }
+Capybara.default_max_wait_time = 10
+
 # Setup for system tests
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :my_playwright
-
-  def setup
-    Capybara.server = :puma, { Silent: true }
-    Capybara.default_max_wait_time = 10
-    super
-  end
 
   def teardown
     ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
I noticed that sometimes the `Silent: true` configuration doesn't take effect, but sometimes it doesn't. This seems to resolve that.