### PR TITLE
Add watch progress bars for shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As mentioned on [the credits page](/credits), this whole thing is open source, s
 
 But here's some highlights of when things happened.
 
+1. **July 14, 2025** — Add watch progress bars showing percentage of episodes watched for each show on both the shows index and individual show pages
 1. **July 12, 2025** — Unified search and import experience: Search now queries TMDB directly and shows importable shows alongside imported ones, eliminating the separate import page
 1. **July 9, 2025** — Show lock emoji on private reviews with tooltip explaining visibility
 1. **July 9, 2025** — Add ability to edit season reviews (body, rating, visibility)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,11 @@ node_modules/.bin/prettier --write .
 
 **Terminology**: Use "human" not "user" - the core model is `Human`, not `User`. This is deliberate terminology throughout the codebase.
 
+**SQL Writing**:
+
+- Prefer lowercase keywords
+- When writing complex sql queries, and creating aliases for tables, prefer long descriptive names (e.g. humans_seasons) over short, non-obvious aliases like s2
+
 ## UI/UX Style Guide
 
 - Prefer sentence case for buttons and labels (not title case)
@@ -168,3 +173,7 @@ node_modules/.bin/prettier --write .
 ## Changelog Practices
 
 - When checking what the current date is while updating the changelog, shell out to date to double check the date in local time
+
+## File References
+
+- Reference @db/schema.rb to see the database schema

--- a/app/views/shows/index.html.erb
+++ b/app/views/shows/index.html.erb
@@ -44,6 +44,17 @@
                 <% else %>
                   <span>&mdash;</span>
                 <% end %>
+                <% if (percentage = my_show.watched_percentage) > 0 %>
+                  <div class="mt-2 w-full">
+                    <div class="flex justify-between text-xs text-gray-600 mb-1">
+                      <span>Progress</span>
+                      <span><%= percentage %>%</span>
+                    </div>
+                    <div class="w-full bg-gray-200 rounded-full h-2">
+                      <div class="bg-orange-500 h-2 rounded-full transition-all duration-300" style="width: <%= percentage %>%"></div>
+                    </div>
+                  </div>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/shows/show.html.erb
+++ b/app/views/shows/show.html.erb
@@ -17,6 +17,16 @@
       <div class="my-2">
         <%= render "note_to_self", my_show: @my_show %>
       </div>
+      <% if (percentage = @my_show.watched_percentage) > 0 %>
+        <div class="my-4 max-w-md">
+          <div class="flex justify-end text-sm text-gray-600 mb-2">
+            <span><%= percentage %>%</span>
+          </div>
+          <div class="w-full bg-gray-200 rounded-full h-3" title="Watch progress">
+            <div class="bg-orange-500 h-3 rounded-full transition-all duration-300" style="width: <%= percentage %>%"></div>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 

--- a/test/models/my_show_test.rb
+++ b/test/models/my_show_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+# unit tests for MyShow model
+class MyShowTest < ActiveSupport::TestCase
+  test "watched_percentage returns 0 when no episodes exist" do
+    human = Human.create!(handle: "donna_clark", email: "donna@example.com")
+    show = Show.create!(title: "Halt and Catch Fire", tmdb_tv_id: 123)
+    my_show = MyShow.create!(human: human, show: show, status: "currently_watching")
+
+    assert_in_delta(0.0, my_show.watched_percentage)
+  end
+
+  test "watched_percentage returns 0 when no episodes watched" do
+    human = Human.create!(handle: "donna_clark", email: "donna@example.com")
+    show = Show.create!(title: "Halt and Catch Fire", tmdb_tv_id: 123)
+    season = Season.create!(show: show, season_number: 1, name: "Season 1", tmdb_id: 456, episode_count: 2)
+    Episode.create!(season: season, episode_number: 1, air_date: 1.day.ago, tmdb_id: 789, name: "Episode 1")
+    Episode.create!(season: season, episode_number: 2, air_date: 1.day.ago, tmdb_id: 790, name: "Episode 2")
+    my_show = MyShow.create!(human: human, show: show, status: "currently_watching")
+
+    assert_in_delta(0.0, my_show.watched_percentage)
+  end
+
+  test "watched_percentage returns 100 when all episodes watched" do
+    human = Human.create!(handle: "donna_clark", email: "donna@example.com")
+    show = Show.create!(title: "Halt and Catch Fire", tmdb_tv_id: 123)
+    season = Season.create!(show: show, season_number: 1, name: "Season 1", tmdb_id: 456, episode_count: 2)
+    Episode.create!(season: season, episode_number: 1, air_date: 1.day.ago, tmdb_id: 789, name: "Episode 1")
+    Episode.create!(season: season, episode_number: 2, air_date: 1.day.ago, tmdb_id: 790, name: "Episode 2")
+    my_show = MyShow.create!(human: human, show: show, status: "currently_watching")
+    MySeason.create!(human: human, season: season, watched_episode_numbers: [1, 2])
+
+    assert_in_delta(100.0, my_show.watched_percentage)
+  end
+
+  test "watched_percentage returns correct percentage for partial viewing" do
+    human = Human.create!(handle: "donna_clark", email: "donna@example.com")
+    show = Show.create!(title: "Halt and Catch Fire", tmdb_tv_id: 123)
+    season = Season.create!(show: show, season_number: 1, name: "Season 1", tmdb_id: 456, episode_count: 4)
+    Episode.create!(season: season, episode_number: 1, air_date: 1.day.ago, tmdb_id: 789, name: "Episode 1")
+    Episode.create!(season: season, episode_number: 2, air_date: 1.day.ago, tmdb_id: 790, name: "Episode 2")
+    Episode.create!(season: season, episode_number: 3, air_date: 1.day.ago, tmdb_id: 791, name: "Episode 3")
+    Episode.create!(season: season, episode_number: 4, air_date: 1.day.ago, tmdb_id: 792, name: "Episode 4")
+    my_show = MyShow.create!(human: human, show: show, status: "currently_watching")
+    MySeason.create!(human: human, season: season, watched_episode_numbers: [1, 2])
+
+    assert_in_delta(50.0, my_show.watched_percentage)
+  end
+
+  test "watched_percentage excludes future episodes" do
+    human = Human.create!(handle: "donna_clark", email: "donna@example.com")
+    show = Show.create!(title: "Halt and Catch Fire", tmdb_tv_id: 123)
+    season = Season.create!(show: show, season_number: 1, name: "Season 1", tmdb_id: 456, episode_count: 3)
+    Episode.create!(season: season, episode_number: 1, air_date: 1.day.ago, tmdb_id: 789, name: "Episode 1")
+    Episode.create!(season: season, episode_number: 2, air_date: 1.day.ago, tmdb_id: 790, name: "Episode 2")
+    Episode.create!(season: season, episode_number: 3, air_date: 1.day.from_now, tmdb_id: 791, name: "Episode 3")
+    my_show = MyShow.create!(human: human, show: show, status: "currently_watching")
+    MySeason.create!(human: human, season: season, watched_episode_numbers: [1, 2])
+
+    assert_in_delta(100.0, my_show.watched_percentage)
+  end
+
+  test "watched_percentage works across multiple seasons" do
+    human = Human.create!(handle: "donna_clark", email: "donna@example.com")
+    show = Show.create!(title: "Halt and Catch Fire", tmdb_tv_id: 123)
+
+    season1 = Season.create!(show: show, season_number: 1, name: "Season 1", tmdb_id: 456, episode_count: 2)
+    Episode.create!(season: season1, episode_number: 1, air_date: 1.day.ago, tmdb_id: 789, name: "Episode 1")
+    Episode.create!(season: season1, episode_number: 2, air_date: 1.day.ago, tmdb_id: 790, name: "Episode 2")
+
+    season2 = Season.create!(show: show, season_number: 2, name: "Season 2", tmdb_id: 457, episode_count: 2)
+    Episode.create!(season: season2, episode_number: 1, air_date: 1.day.ago, tmdb_id: 791, name: "Episode 1")
+    Episode.create!(season: season2, episode_number: 2, air_date: 1.day.ago, tmdb_id: 792, name: "Episode 2")
+
+    my_show = MyShow.create!(human: human, show: show, status: "currently_watching")
+    MySeason.create!(human: human, season: season1, watched_episode_numbers: [1, 2])
+    MySeason.create!(human: human, season: season2, watched_episode_numbers: [1])
+
+    assert_in_delta(75.0, my_show.watched_percentage)
+  end
+end


### PR DESCRIPTION
Shows now display a visual progress bar indicating what percentage of episodes have been watched. The percentage is calculated using an efficient database query that only counts aired episodes. Progress bars appear on both the shows index page and individual show pages when progress is > 0%.

🤖 Generated with [Claude Code](https://claude.ai/code)