### PR TITLE
Add season progress bars to individual season pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ As mentioned on [the credits page](/credits), this whole thing is open source, s
 
 But here's some highlights of when things happened.
 
+1. **September 6, 2025** — Add season progress bars to individual season pages showing percentage of episodes watched in that season
 1. **September 6, 2025** — Add toggle to stats pages allowing users to view seasons reviewed during a year vs seasons that originally aired during a year, providing richer insights into viewing habits
 1. **August 24, 2025** — Can mark episodes as seen from the episode show page
 1. **August 24, 2025** — Add personal stats pages showing year-by-year review statistics with top 25 favorite seasons. Available at `/your-handle/stats` with year navigation.

--- a/app/models/my_season.rb
+++ b/app/models/my_season.rb
@@ -14,4 +14,12 @@ class MySeason < ApplicationRecord
   def episode_watched?(episode_number)
     watched_episode_numbers.include?(episode_number)
   end
+
+  def watched_percentage
+    total_episodes = season.episode_count
+    return 0 if total_episodes.zero?
+
+    watched_episodes = watched_episode_numbers.length
+    (watched_episodes.to_f / total_episodes * 100).floor
+  end
 end

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -26,6 +26,18 @@
     <div>
       <h2 class="text-lg font-medium text-gray-900 mb-4">Episodes</h2>
 
+      <% if current_human.present? && @my_season %>
+        <% percentage = @my_season.watched_percentage %>
+        <div class="max-w-full sm:max-w-md mb-6">
+          <div class="flex justify-end text-sm text-gray-600 mb-2">
+            <span><%= number_to_percentage(percentage, precision: 0) %></span>
+          </div>
+          <div class="w-full bg-gray-200 rounded-full h-3" title="Season watch progress">
+            <div class="bg-orange-500 h-3 rounded-full transition-all duration-300" style="width: <%= percentage %>%"></div>
+          </div>
+        </div>
+      <% end %>
+
       <div class="overflow-x-auto">
         <table class="w-full border-collapse">
           <thead>


### PR DESCRIPTION
Shows percentage of episodes watched in that specific season, displayed above the episodes table. Progress is calculated using floor rounding for consistent integer percentages.

🤖 Generated with [Claude Code](https://claude.ai/code)