### PR TITLE
remove Heroku references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Seasoning is a Ruby on Rails application for tracking TV show viewing progress.
 - JavaScript: jsbundling-rails with esbuild for bundling
 - Testing: Minitest (Rails), Capybara with Playwright for system tests
 - API: The Movie Database (TMDB) for show data
-- Deployment: Heroku with Heroku Scheduler for background tasks
+- Deployment: Raspberry Pi 5 with systemd for background tasks, Cloudflare tunnel for public access
 
 ## Development Commands
 
@@ -137,7 +137,7 @@ node_modules/.bin/prettier --write .  # Formatting
 - The maskable icon is generated with ImageMagick: orange background + icon centered at ~80% size
 - Install prompt logic is in `app/javascript/install-prompt.js`; intercepts `beforeinstallprompt` and shows a hidden nav button
 
-## Scheduled Tasks (Heroku Scheduler)
+## Scheduled Tasks (systemd timer: seasoning-nightly.service)
 
 - `prune:all` - Daily cleanup of expired MagicLink records
 - `db:sessions:trim` - Daily cleanup of Rails sessions (midnight UTC, 180-day threshold)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Your couch away from your couch.
 
-Deploying to: <http://seasoning.herokuapp.com/> aka <https://www.seasoning.tv>
+Deploying to: <https://www.seasoning.tv>
 
 Demo: <https://www.youtube.com/watch?v=4aB6LbN2ff8>
 
@@ -27,7 +27,7 @@ And visit <http://localhost:3000>
 To run the tests locally:
 
 ```
-corepack npm run build:css
+npm run build:css
 bin/rails test:all
 ```
 

--- a/app/models/tmdb_api_configuration.rb
+++ b/app/models/tmdb_api_configuration.rb
@@ -1,7 +1,7 @@
 # Persists the TMDB API configuration as recommended here:
 # https://developers.themoviedb.org/3/configuration/get-api-configuration
 #
-# Is refreshed every few days via https://dashboard.heroku.com/apps/seasoning/scheduler
+# Is refreshed daily via systemd timer (seasoning-nightly.service)
 #
 # There should always be exactly one record in this table
 class TMDBAPIConfiguration < ApplicationRecord

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,7 +1,6 @@
 Bugsnag.configure do |config|
   config.api_key = ENV.fetch("BUGSNAG_API_KEY")
   config.enabled_release_stages = ["production"]
-  config.app_version = ENV.fetch("HEROKU_RELEASE_VERSION", nil)
   config.ignore_classes = [
     "ActiveRecord::RecordNotFound",
     "ActionController::UnknownFormat",

--- a/lib/tasks/new_season_checker.rake
+++ b/lib/tasks/new_season_checker.rake
@@ -1,5 +1,5 @@
 namespace :new_season_checker do
-  # Run daily via https://dashboard.heroku.com/apps/seasoning/scheduler
+  # Run daily via systemd timer (seasoning-nightly.service)
   task toggle: :environment do
     my_shows = MyShow.where(status: ["waiting", "finished"])
     my_shows.find_each do |my_show|

--- a/lib/tasks/prune.rake
+++ b/lib/tasks/prune.rake
@@ -1,10 +1,5 @@
 namespace :prune do
-  # This just prunes some records which don't strictly need to exist anymore.
-  # We're nowhere near hitting it, but there is a 10k rows limit in our database
-  # that we will quickly hit if the site actually takes off, so this is just
-  # to help delay that a little.
-  #
-  # Run daily via https://dashboard.heroku.com/apps/seasoning/scheduler
+  # Run daily via systemd timer (seasoning-nightly.service)
   task all: :environment do
     links = MagicLink.inactive.destroy_all
     puts "Destroyed #{links.count} magic links"

--- a/lib/tasks/tmdb.rake
+++ b/lib/tasks/tmdb.rake
@@ -1,7 +1,7 @@
 namespace :tmdb do
   # Refresh the configuration record
   #
-  # Run daily via https://dashboard.heroku.com/apps/seasoning/scheduler
+  # Run daily via systemd timer (seasoning-nightly.service)
   task refresh_config: :environment do
     TMDBAPIConfiguration.refresh!
   end
@@ -12,7 +12,7 @@ namespace :tmdb do
   #
   # Plus other various changes, like the default poster changing...
   #
-  # Run daily via https://dashboard.heroku.com/apps/seasoning/scheduler
+  # Run daily via systemd timer (seasoning-nightly.service)
   task refresh_shows: :environment do
     Show.needs_refreshing.find_each do |show|
       puts "Refreshing #{show.slug} asynchronously"


### PR DESCRIPTION
The app is no longer deployed on Heroku. Update references to the scheduler, deployment docs, and app version tracking.