### PR TITLE
Improve sticky header spacing and search input style

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -81,7 +81,7 @@ a.no-underline:hover {
 }
 
 .text-field {
-  @apply focus:border-yellow-400 focus:ring-yellow-400;
+  @apply rounded-md focus:border-yellow-400 focus:ring-yellow-400;
 }
 
 .select-field {
@@ -121,7 +121,7 @@ a.no-underline:hover {
 /* PWA standalone mode: pad sticky nav for notch/dynamic island */
 @media (display-mode: standalone) {
   .sticky.top-0 {
-    padding-top: env(safe-area-inset-top);
+    padding-top: calc(0.5rem + env(safe-area-inset-top));
   }
 
   body {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
     <div>
       <div
         class="
-          sticky top-0 z-10 bg-gray-100 mx-1 my-2 pb-4 flex flex-col
+          sticky top-0 z-10 bg-gray-100 mx-1 mb-2 pt-2 pb-4 flex flex-col
           justify-between md:flex-row border-b border-gray-200
         "
       >


### PR DESCRIPTION
## Summary

- Converts the sticky nav's top `margin` to `padding` so the spacing above the content is preserved when scrolled (margins are consumed by sticky positioning; padding is not)
- Adds `rounded-md` to the `.text-field` class so the search input has a slight border radius instead of sharp corners
- Updates the PWA standalone safe-area rule to stack the notch inset on top of the new padding rather than replacing it